### PR TITLE
Fix serverless upgrader app authentication

### DIFF
--- a/scripts/upgrader/deployment.py
+++ b/scripts/upgrader/deployment.py
@@ -190,8 +190,63 @@ def deploy_app(
     )
 
 
+def _exchange_app_audience_token(
+    workspace_client: Any,
+    app_name: str,
+    workspace_headers: dict[str, str],
+    timeout_seconds: int,
+) -> dict[str, str]:
+    """Exchange a notebook token for an OAuth token scoped to the app."""
+    authorization = workspace_headers.get("Authorization", "")
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        raise DeploymentError(
+            "Workspace authentication did not provide a Bearer token for "
+            "Databricks App token exchange."
+        )
+
+    app = workspace_client.apps.get(app_name)
+    app_client_id = str(getattr(app, "oauth2_app_client_id", "") or "")
+    if not app_client_id:
+        raise DeploymentError(
+            f"Databricks App '{app_name}' has no OAuth client ID."
+        )
+
+    host = workspace_client.config.host.rstrip("/")
+    response = requests.post(
+        f"{host}/oidc/v1/token",
+        data={
+            "grant_type": (
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+            ),
+            "subject_token": authorization[len(prefix):],
+            "subject_token_type": (
+                "urn:databricks:params:oauth:token-type:personal-access-token"
+            ),
+            "requested_token_type": (
+                "urn:ietf:params:oauth:token-type:access_token"
+            ),
+            "scope": "all-apis",
+            "audience": app_client_id,
+        },
+        timeout=timeout_seconds,
+    )
+    if response.status_code != 200:
+        raise DeploymentError(
+            "Databricks App token exchange failed: "
+            f"HTTP {response.status_code} {response.text[:300]}"
+        )
+    access_token = str(response.json().get("access_token", "") or "")
+    if not access_token:
+        raise DeploymentError(
+            "Databricks App token exchange returned no access token."
+        )
+    return {"Authorization": f"Bearer {access_token}"}
+
+
 def verify_app(
     workspace_client: Any,
+    app_name: str,
     app_url: str,
     expected_version: str,
     timeout_seconds: int = 30,
@@ -203,6 +258,18 @@ def verify_app(
         headers=headers,
         timeout=timeout_seconds,
     )
+    if health.status_code == 401:
+        headers = _exchange_app_audience_token(
+            workspace_client,
+            app_name,
+            headers,
+            timeout_seconds,
+        )
+        health = requests.get(
+            f"{app_url.rstrip('/')}/api/v1/system/health",
+            headers=headers,
+            timeout=timeout_seconds,
+        )
     if health.status_code != 200:
         raise DeploymentError(
             f"Health check returned HTTP {health.status_code}."

--- a/scripts/upgrader/runner.py
+++ b/scripts/upgrader/runner.py
@@ -318,6 +318,7 @@ def apply_upgrade(
 
         verification = verify_app(
             workspace_client,
+            installation.app_name,
             installation.app_url,
             str(plan.manifest.version),
         )

--- a/tests/upgrade/test_deployment.py
+++ b/tests/upgrade/test_deployment.py
@@ -103,11 +103,139 @@ def test_verification_is_authenticated_and_checks_database(monkeypatch):
         },
     )()
 
-    verify_app(client, "https://meter.example", "0.1.1")
+    verify_app(client, "lakemeter", "https://meter.example", "0.1.1")
 
     assert calls[0][0].endswith("/api/v1/system/health")
     assert calls[1][0].endswith("/api/v1/system/version")
     assert all(call[1]["Authorization"] == "Bearer token" for call in calls)
+
+
+def test_verification_exchanges_notebook_token_after_401(monkeypatch):
+    calls = []
+    responses = iter(
+        [
+            (401, {"error": "unauthorized"}),
+            (200, {"status": "healthy", "database": "connected"}),
+            (200, {"app_version": "0.1.1"}),
+        ]
+    )
+
+    class Response:
+        def __init__(self, status_code, body, text=""):
+            self.status_code = status_code
+            self.body = body
+            self.text = text
+
+        def json(self):
+            return self.body
+
+    def fake_get(url, headers, timeout):
+        calls.append((url, headers, timeout))
+        status_code, body = next(responses)
+        return Response(status_code, body)
+
+    def fake_post(url, data, timeout):
+        assert url == "https://workspace.example/oidc/v1/token"
+        assert data == {
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "notebook-token",
+            "subject_token_type": (
+                "urn:databricks:params:oauth:token-type:personal-access-token"
+            ),
+            "requested_token_type": (
+                "urn:ietf:params:oauth:token-type:access_token"
+            ),
+            "scope": "all-apis",
+            "audience": "app-client-id",
+        }
+        assert timeout == 30
+        return Response(200, {"access_token": "app-audience-token"})
+
+    monkeypatch.setattr("upgrader.deployment.requests.get", fake_get)
+    monkeypatch.setattr("upgrader.deployment.requests.post", fake_post)
+    client = type(
+        "Client",
+        (),
+        {
+            "config": type(
+                "Config",
+                (),
+                {
+                    "host": "https://workspace.example",
+                    "authenticate": lambda _self: {
+                        "Authorization": "Bearer notebook-token"
+                    },
+                },
+            )(),
+            "apps": SimpleNamespace(
+                get=lambda _name: SimpleNamespace(
+                    oauth2_app_client_id="app-client-id"
+                )
+            ),
+        },
+    )()
+
+    verify_app(client, "lakemeter", "https://meter.example", "0.1.1")
+
+    assert len(calls) == 3
+    assert calls[0][1]["Authorization"] == "Bearer notebook-token"
+    assert all(
+        call[1]["Authorization"] == "Bearer app-audience-token"
+        for call in calls[1:]
+    )
+
+
+def test_verification_reports_app_token_exchange_failure(monkeypatch):
+    class Response:
+        def __init__(self, status_code, body, text=""):
+            self.status_code = status_code
+            self.body = body
+            self.text = text
+
+        def json(self):
+            return self.body
+
+    monkeypatch.setattr(
+        "upgrader.deployment.requests.get",
+        lambda *_args, **_kwargs: Response(401, {}),
+    )
+    monkeypatch.setattr(
+        "upgrader.deployment.requests.post",
+        lambda *_args, **_kwargs: Response(
+            400,
+            {"error": "invalid_request"},
+            text="invalid token exchange",
+        ),
+    )
+    client = type(
+        "Client",
+        (),
+        {
+            "config": type(
+                "Config",
+                (),
+                {
+                    "host": "https://workspace.example",
+                    "authenticate": lambda _self: {
+                        "Authorization": "Bearer notebook-token"
+                    },
+                },
+            )(),
+            "apps": SimpleNamespace(
+                get=lambda _name: SimpleNamespace(
+                    oauth2_app_client_id="app-client-id"
+                )
+            ),
+        },
+    )()
+
+    with pytest.raises(DeploymentError, match="token exchange failed"):
+        verify_app(
+            client,
+            "lakemeter",
+            "https://meter.example",
+            "0.1.1",
+        )
 
 
 def test_versioned_release_path_rejects_different_runtime(tmp_path):


### PR DESCRIPTION
## Summary
- exchange the serverless notebook credential for an OAuth token scoped to the target Databricks App when direct verification returns HTTP 401
- reuse the app-scoped token for authenticated health, database, and version checks while preserving direct local authentication
- add regression coverage for successful token exchange and exchange failures

## Test plan
- [x] `python -m pytest tests/upgrade tests/schema/test_line_item_schema_alignment.py -q` — 43 passed
- [x] `python scripts/prepare_release.py --check`
- [x] install published `v0.1.0` in the `lakemeter` workspace
- [x] reproduce the AI Parse persistence defect with 2.5K high-complexity pages (218.75 DBU/month)
- [x] run `upgrade.sh status`, `plan`, and `doctor`
- [x] run the standard serverless `upgrade.sh apply` path to `v0.1.1` — completed successfully without the prior HTTP 401 rollback
- [x] verify app health/database connectivity and AI Parse persistence for updated, new, and cloned items
- [x] delete the temporary regression estimate