### PR TITLE
Fix Databricks Apps SKU pricing

### DIFF
--- a/backend/app/routes/calculate/databricks_apps_calc.py
+++ b/backend/app/routes/calculate/databricks_apps_calc.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.services.validators import validate_cloud, validate_region, validate_tier, validate_sku_specific_discounts
-from app.services.lakebase_queries import get_product_type_for_pricing
 from app.routes.calculate.helpers import build_sku_breakdown_serverless
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
@@ -23,6 +22,7 @@ APPS_DBU_RATES = {
     "medium": 0.5,
     "large": 1.0,
 }
+DATABRICKS_APPS_SKU = "ALL_PURPOSE_SERVERLESS_COMPUTE"
 
 
 @router.post("/calculate/databricks-apps", tags=["Cost Calculation"])
@@ -49,7 +49,7 @@ def calculate_databricks_apps_cost(
         dbu_per_hour = APPS_DBU_RATES[size]
         dbu_per_month = dbu_per_hour * hours_per_month
 
-        sku_type = get_product_type_for_pricing(db, "DATABRICKS_APPS", True, False, None, None, None)
+        sku_type = DATABRICKS_APPS_SKU
         # Look up DBU price
         from sqlalchemy import text
         price_row = db.execute(text("""

--- a/backend/app/routes/calculate/helpers.py
+++ b/backend/app/routes/calculate/helpers.py
@@ -62,8 +62,16 @@ def get_sku_type(
     elif workload_upper == "LAKEBASE":
         return "DATABASE_SERVERLESS_COMPUTE"
 
-    else:
-        return "JOBS_COMPUTE"
+    elif workload_upper == "DATABRICKS_APPS":
+        return "ALL_PURPOSE_SERVERLESS_COMPUTE"
+
+    elif workload_upper in ("AI_PARSE", "SHUTTERSTOCK_IMAGEAI"):
+        return "SERVERLESS_REAL_TIME_INFERENCE"
+
+    elif workload_upper == "LAKEFLOW_CONNECT":
+        return "JOBS_SERVERLESS_COMPUTE"
+
+    raise ValueError(f"Unsupported workload type: {workload_type!r}")
 
 
 def build_sku_breakdown_classic(

--- a/backend/app/routes/export/pricing.py
+++ b/backend/app/routes/export/pricing.py
@@ -124,7 +124,9 @@ def _get_sku_type(item, cloud: str = 'aws') -> str:
         return 'SERVERLESS_REAL_TIME_INFERENCE'
     elif wt == 'SHUTTERSTOCK_IMAGEAI':
         return 'SERVERLESS_REAL_TIME_INFERENCE'
-    return 'JOBS_COMPUTE'
+    elif wt == 'LAKEFLOW_CONNECT':
+        return 'JOBS_SERVERLESS_COMPUTE'
+    raise ValueError(f"Unsupported workload type: {item.workload_type!r}")
 
 
 def _get_fmapi_sku(item, cloud: str) -> str:

--- a/backend/app/services/lakebase_queries.py
+++ b/backend/app/services/lakebase_queries.py
@@ -171,4 +171,11 @@ def get_sku_type(
     if wt == "LAKEBASE":
         return "DATABASE_SERVERLESS_COMPUTE"
 
-    return "JOBS_COMPUTE"
+    if wt == "DATABRICKS_APPS":
+        return "ALL_PURPOSE_SERVERLESS_COMPUTE"
+    if wt in ("AI_PARSE", "SHUTTERSTOCK_IMAGEAI"):
+        return "SERVERLESS_REAL_TIME_INFERENCE"
+    if wt == "LAKEFLOW_CONNECT":
+        return "JOBS_SERVERLESS_COMPUTE"
+
+    raise ValueError(f"Unsupported workload type: {workload_type!r}")

--- a/etl/lakebase_setup/functions/01_Utility_Functions.py
+++ b/etl/lakebase_setup/functions/01_Utility_Functions.py
@@ -240,10 +240,22 @@ BEGIN
         
         WHEN 'LAKEBASE' THEN
             v_product_type := 'DATABASE_SERVERLESS_COMPUTE';
+
+        WHEN 'DATABRICKS_APPS' THEN
+            v_product_type := 'ALL_PURPOSE_SERVERLESS_COMPUTE';
+
+        WHEN 'AI_PARSE' THEN
+            v_product_type := 'SERVERLESS_REAL_TIME_INFERENCE';
+
+        WHEN 'SHUTTERSTOCK_IMAGEAI' THEN
+            v_product_type := 'SERVERLESS_REAL_TIME_INFERENCE';
+
+        WHEN 'LAKEFLOW_CONNECT' THEN
+            v_product_type := 'JOBS_SERVERLESS_COMPUTE';
         
-        -- Default
         ELSE
-            v_product_type := 'JOBS_COMPUTE';
+            RAISE EXCEPTION 'Unsupported workload type: %', p_workload_type
+                USING ERRCODE = '22023';
     END CASE;
     
     RETURN v_product_type;

--- a/scripts/functions/01_Utility_Functions.py
+++ b/scripts/functions/01_Utility_Functions.py
@@ -239,10 +239,22 @@ BEGIN
         
         WHEN 'LAKEBASE' THEN
             v_product_type := 'DATABASE_SERVERLESS_COMPUTE';
+
+        WHEN 'DATABRICKS_APPS' THEN
+            v_product_type := 'ALL_PURPOSE_SERVERLESS_COMPUTE';
+
+        WHEN 'AI_PARSE' THEN
+            v_product_type := 'SERVERLESS_REAL_TIME_INFERENCE';
+
+        WHEN 'SHUTTERSTOCK_IMAGEAI' THEN
+            v_product_type := 'SERVERLESS_REAL_TIME_INFERENCE';
+
+        WHEN 'LAKEFLOW_CONNECT' THEN
+            v_product_type := 'JOBS_SERVERLESS_COMPUTE';
         
-        -- Default
         ELSE
-            v_product_type := 'JOBS_COMPUTE';
+            RAISE EXCEPTION 'Unsupported workload type: %', p_workload_type
+                USING ERRCODE = '22023';
     END CASE;
     
     RETURN v_product_type;

--- a/tests/export/sku_alignment/test_sku_resolution.py
+++ b/tests/export/sku_alignment/test_sku_resolution.py
@@ -180,8 +180,10 @@ class TestDatabricksAppsSKU:
 class TestDefaultSKU:
     def test_empty_workload_type(self):
         item = make_line_item(workload_type='')
-        assert _get_sku_type(item, 'aws') == 'JOBS_COMPUTE'
+        with pytest.raises(ValueError, match="Unsupported workload type"):
+            _get_sku_type(item, 'aws')
 
     def test_none_workload_type(self):
         item = make_line_item(workload_type=None)
-        assert _get_sku_type(item, 'aws') == 'JOBS_COMPUTE'
+        with pytest.raises(ValueError, match="Unsupported workload type"):
+            _get_sku_type(item, 'aws')

--- a/tests/regression/test_databricks_apps_sku_pricing.py
+++ b/tests/regression/test_databricks_apps_sku_pricing.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.routes.calculate import databricks_apps_calc
+from app.routes.calculate.databricks_apps_calc import (
+    DATABRICKS_APPS_SKU,
+    calculate_databricks_apps_cost,
+)
+from app.routes.calculate.helpers import get_sku_type as get_calculation_sku_type
+from app.routes.calculate.schemas import DatabricksAppsCalculationRequest
+from app.routes.export.calculations import (
+    _calculate_dbu_per_hour,
+    _calculate_hours_per_month,
+)
+from app.routes.export.pricing import _get_sku_type as get_export_sku_type
+from app.services.lakebase_queries import get_sku_type as get_service_sku_type
+
+
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _PricingDb:
+    PRICES = {
+        "JOBS_COMPUTE": 0.15,
+        DATABRICKS_APPS_SKU: 0.75,
+    }
+
+    def __init__(self):
+        self.product_types = []
+
+    def execute(self, statement, params):
+        sql = str(statement)
+        if "get_product_type_for_pricing" in sql:
+            return _Result(SimpleNamespace(product_type="JOBS_COMPUTE"))
+
+        product_type = params["pt"]
+        self.product_types.append(product_type)
+        return _Result(
+            SimpleNamespace(price_per_dbu=self.PRICES[product_type])
+        )
+
+
+@pytest.fixture(autouse=True)
+def _patch_validation(monkeypatch):
+    monkeypatch.setattr(
+        databricks_apps_calc, "validate_cloud", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        databricks_apps_calc, "validate_region", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        databricks_apps_calc, "validate_tier", lambda *_args, **_kwargs: None
+    )
+
+
+@pytest.mark.parametrize(
+    ("size", "expected_dbu_per_hour"),
+    [("medium", 0.5), ("large", 1.0)],
+)
+def test_calculate_and_export_use_apps_serverless_sku(
+    size, expected_dbu_per_hour
+):
+    db = _PricingDb()
+    hours_per_month = 730
+
+    response = calculate_databricks_apps_cost(
+        DatabricksAppsCalculationRequest(
+            cloud="AWS",
+            region="us-east-1",
+            tier="PREMIUM",
+            size=size,
+            hours_per_month=hours_per_month,
+        ),
+        db=db,
+    )
+    api_data = response["data"]
+
+    export_item = SimpleNamespace(
+        workload_type="DATABRICKS_APPS",
+        databricks_apps_size=size,
+        runs_per_day=None,
+        avg_runtime_minutes=None,
+        hours_per_month=hours_per_month,
+    )
+    export_sku = get_export_sku_type(export_item, "aws")
+    export_dbu_per_hour, warnings = _calculate_dbu_per_hour(
+        export_item, "aws", "PREMIUM"
+    )
+    export_hours = _calculate_hours_per_month(export_item)
+    export_cost = export_dbu_per_hour * export_hours * 0.75
+
+    assert api_data["sku_type"] == DATABRICKS_APPS_SKU
+    assert export_sku == DATABRICKS_APPS_SKU
+    assert db.product_types == [DATABRICKS_APPS_SKU]
+    assert api_data["dbu_calculation"]["dbu_per_hour"] == expected_dbu_per_hour
+    assert export_dbu_per_hour == expected_dbu_per_hour
+    assert warnings == []
+    assert api_data["total_cost"]["cost_per_month"] == pytest.approx(
+        export_cost
+    )
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    [get_calculation_sku_type, get_service_sku_type],
+)
+def test_python_sku_resolvers_reject_unknown_workloads(resolver):
+    with pytest.raises(ValueError, match="Unsupported workload type"):
+        resolver("NOT_A_WORKLOAD")
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "scripts/functions/01_Utility_Functions.py",
+        "etl/lakebase_setup/functions/01_Utility_Functions.py",
+    ],
+)
+def test_sql_sku_resolvers_map_apps_and_reject_unknown_workloads(
+    relative_path,
+):
+    repository_root = Path(__file__).parents[2]
+    source = (repository_root / relative_path).read_text()
+
+    assert "WHEN 'DATABRICKS_APPS' THEN" in source
+    assert "v_product_type := 'ALL_PURPOSE_SERVERLESS_COMPUTE';" in source
+    assert "RAISE EXCEPTION 'Unsupported workload type: %'" in source


### PR DESCRIPTION
## Summary
- price Databricks Apps with `ALL_PURPOSE_SERVERLESS_COMPUTE` across calculation and stored SKU resolvers
- reject unsupported workload types instead of silently falling back to Jobs compute
- add regression coverage for API/export pricing parity and strict resolver behavior

## Test plan
- [x] `python -m pytest tests/regression/test_databricks_apps_sku_pricing.py tests/export/sku_alignment/test_sku_resolution.py -q` (34 passed)
- [x] fresh Lakebase + Databricks App installer smoke suite passed
- [x] live medium Apps calculation verified at 0.5 DBU/hour and $273.75/month
- [x] broader suite: 153 passed; 3 unrelated failures reproduced on clean `main`

Closes #7