### PR TITLE
Fix hours-per-day normalization across calculation APIs

### DIFF
--- a/backend/app/routes/calculate/all_purpose.py
+++ b/backend/app/routes/calculate/all_purpose.py
@@ -10,7 +10,7 @@ from app.routes.calculate.helpers import build_sku_breakdown_classic, build_sku_
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
 )
-from app.routes.calculate.jobs import _validate_usage_params, _validate_classic_inputs, _validate_serverless_inputs
+from app.routes.calculate.jobs import normalize_usage_params, _validate_classic_inputs, _validate_serverless_inputs
 from app.routes.calculate.schemas import AllPurposeClassicCalculationRequest, AllPurposeServerlessCalculationRequest
 
 logger = logging.getLogger(__name__)
@@ -22,14 +22,7 @@ def calculate_all_purpose_classic_cost(
     request: AllPurposeClassicCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    # Convert hours_per_day to hours_per_month if provided
-    if getattr(request, 'hours_per_day', None) is not None and request.hours_per_month is None:
-        days = request.days_per_month or 30
-        request.hours_per_month = request.hours_per_day * days
-
-    has_run_params, has_hours = _validate_usage_params(request)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="daily_or_monthly")
 
     _validate_classic_inputs(request, db)
 
@@ -39,10 +32,9 @@ def calculate_all_purpose_classic_cost(
             "p5": False, "p6": request.photon_enabled, "p7": None,
             "p8": request.driver_node_type, "p9": request.worker_node_type, "p10": request.num_workers,
             "p11": request.driver_pricing_tier, "p12": request.worker_pricing_tier,
-            "p13": getattr(request, 'runs_per_day', 0) or 0,
-            "p14": getattr(request, 'avg_runtime_minutes', 0) or 0,
-            "p15": request.days_per_month if has_run_params else 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": 0, "p14": 0,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard", "p18": None, "p19": None, "p20": 1, "p21": "on_demand", "p22": None,
             "p23": 0, "p24": None, "p25": None, "p26": None,
             "p27": "global", "p28": "all", "p29": "input_token", "p30": 0, "p31": 0, "p32": 1,
@@ -125,14 +117,7 @@ def calculate_all_purpose_serverless_cost(
     request: AllPurposeServerlessCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    # Convert hours_per_day to hours_per_month if provided
-    if getattr(request, 'hours_per_day', None) is not None and request.hours_per_month is None:
-        days = request.days_per_month or 30
-        request.hours_per_month = request.hours_per_day * days
-
-    has_run_params, has_hours = _validate_usage_params(request, require_runs=False)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="daily_or_monthly")
 
     _validate_serverless_inputs(request, db)
 
@@ -144,8 +129,8 @@ def calculate_all_purpose_serverless_cost(
             "p10": request.num_workers or 0,
             "p11": "on_demand", "p12": "on_demand",
             "p13": 0, "p14": 0,
-            "p15": request.days_per_month or 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": request.serverless_mode, "p18": None, "p19": None, "p20": 1,
             "p21": "on_demand", "p22": None, "p23": 0, "p24": None, "p25": None, "p26": None,
             "p27": "global", "p28": "all", "p29": "input_token", "p30": 0, "p31": 0, "p32": 1,

--- a/backend/app/routes/calculate/dbsql_calc.py
+++ b/backend/app/routes/calculate/dbsql_calc.py
@@ -15,7 +15,7 @@ from app.routes.calculate.helpers import build_sku_breakdown_classic, build_sku_
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
 )
-from app.routes.calculate.jobs import _validate_usage_params
+from app.routes.calculate.jobs import normalize_usage_params
 from app.routes.calculate.schemas import DBSQLClassicProCalculationRequest, DBSQLServerlessCalculationRequest
 
 logger = logging.getLogger(__name__)
@@ -27,9 +27,7 @@ def calculate_dbsql_classic_pro_cost(
     request: DBSQLClassicProCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request, require_runs=False)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="daily_or_monthly")
 
     error = validate_cloud(request.cloud)
     if error:
@@ -54,8 +52,8 @@ def calculate_dbsql_classic_pro_cost(
             "p8": None, "p9": None, "p10": 0,
             "p11": request.driver_pricing_tier, "p12": request.worker_pricing_tier,
             "p13": 0, "p14": 0,
-            "p15": request.days_per_month or 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard",
             "p18": request.warehouse_type.upper(),
             "p19": request.warehouse_size, "p20": 1,
@@ -140,9 +138,7 @@ def calculate_dbsql_serverless_cost(
     request: DBSQLServerlessCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request, require_runs=False)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="daily_or_monthly")
 
     error = validate_cloud(request.cloud)
     if error:
@@ -159,8 +155,8 @@ def calculate_dbsql_serverless_cost(
             "p1": "DBSQL", "p2": request.cloud.upper(), "p3": request.region, "p4": request.tier.upper(),
             "p5": True, "p6": False, "p7": None, "p8": None, "p9": None, "p10": 0,
             "p11": "on_demand", "p12": "on_demand",
-            "p13": 0, "p14": 0, "p15": request.days_per_month or 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": 0, "p14": 0, "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard", "p18": "SERVERLESS", "p19": request.warehouse_size, "p20": 1,
             "p21": "on_demand", "p22": request.warehouse_size,
             "p23": 0, "p24": None, "p25": None, "p26": None,

--- a/backend/app/routes/calculate/dlt_calc.py
+++ b/backend/app/routes/calculate/dlt_calc.py
@@ -10,7 +10,7 @@ from app.routes.calculate.helpers import build_sku_breakdown_classic, build_sku_
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
 )
-from app.routes.calculate.jobs import _validate_usage_params, _validate_classic_inputs, _validate_serverless_inputs
+from app.routes.calculate.jobs import normalize_usage_params, _validate_classic_inputs, _validate_serverless_inputs
 from app.routes.calculate.schemas import DLTClassicCalculationRequest, DLTServerlessCalculationRequest
 
 logger = logging.getLogger(__name__)
@@ -22,9 +22,7 @@ def calculate_dlt_classic_cost(
     request: DLTClassicCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="runs_or_monthly")
 
     _validate_classic_inputs(request, db)
 
@@ -34,10 +32,10 @@ def calculate_dlt_classic_cost(
             "p5": False, "p6": request.photon_enabled, "p7": request.dlt_edition.upper(),
             "p8": request.driver_node_type, "p9": request.worker_node_type, "p10": request.num_workers,
             "p11": request.driver_pricing_tier, "p12": request.worker_pricing_tier,
-            "p13": request.runs_per_day if has_run_params else 0,
-            "p14": request.avg_runtime_minutes if has_run_params else 0,
-            "p15": request.days_per_month if has_run_params else 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": usage.runs_per_day,
+            "p14": usage.avg_runtime_minutes,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard", "p18": None, "p19": None, "p20": 1, "p21": "on_demand", "p22": None,
             "p23": 0, "p24": None, "p25": None, "p26": None,
             "p27": "global", "p28": "all", "p29": "input_token", "p30": 0, "p31": 0, "p32": 1,
@@ -122,9 +120,7 @@ def calculate_dlt_serverless_cost(
     request: DLTServerlessCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="runs_or_monthly")
 
     _validate_serverless_inputs(request, db)
 
@@ -135,10 +131,10 @@ def calculate_dlt_serverless_cost(
             "p8": request.driver_node_type, "p9": request.worker_node_type,
             "p10": request.num_workers or 0,
             "p11": "on_demand", "p12": "on_demand",
-            "p13": request.runs_per_day if has_run_params else 0,
-            "p14": request.avg_runtime_minutes if has_run_params else 0,
-            "p15": request.days_per_month if has_run_params else 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": usage.runs_per_day,
+            "p14": usage.avg_runtime_minutes,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": request.serverless_mode, "p18": None, "p19": None, "p20": 1,
             "p21": "on_demand", "p22": None, "p23": 0, "p24": None, "p25": None, "p26": None,
             "p27": "global", "p28": "all", "p29": "input_token", "p30": 0, "p31": 0, "p32": 1,

--- a/backend/app/routes/calculate/jobs.py
+++ b/backend/app/routes/calculate/jobs.py
@@ -1,5 +1,8 @@
 """Jobs compute calculation endpoints (Classic + Serverless)."""
+from dataclasses import dataclass
 import logging
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -21,30 +24,80 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _validate_usage_params(request, require_runs=True):
-    """Validate usage params. Returns (has_run_params, has_hours)."""
-    if require_runs:
-        has_run_params = all([
-            getattr(request, 'runs_per_day', None) is not None,
-            getattr(request, 'avg_runtime_minutes', None) is not None,
-        ])
-    else:
-        has_run_params = all([
-            getattr(request, 'hours_per_day', None) is not None,
-        ])
-    has_hours = request.hours_per_month is not None
+@dataclass(frozen=True)
+class NormalizedUsage:
+    runs_per_day: int = 0
+    avg_runtime_minutes: int = 0
+    days_per_month: int = 30
+    hours_per_month: float | None = None
 
-    if not has_run_params and not has_hours:
+
+def normalize_usage_params(
+    request,
+    *,
+    mode: Literal["runs_or_monthly", "daily_or_monthly"],
+) -> NormalizedUsage:
+    """Validate usage inputs and return a normalized, immutable representation."""
+    days_per_month = getattr(request, "days_per_month", None) or 30
+    hours_per_month = getattr(request, "hours_per_month", None)
+
+    if mode == "daily_or_monthly":
+        hours_per_day = getattr(request, "hours_per_day", None)
+        if hours_per_day is not None and hours_per_month is not None:
+            raise HTTPException(status_code=400, detail={
+                "code": "CONFLICTING_USAGE_PARAMETERS",
+                "message": "Cannot provide both hours_per_day and hours_per_month.",
+            })
+        if hours_per_day is None and hours_per_month is None:
+            raise HTTPException(status_code=400, detail={
+                "code": "MISSING_USAGE_PARAMETERS",
+                "message": "Must provide either hours_per_day or hours_per_month.",
+            })
+        normalized_hours = (
+            float(hours_per_day) * days_per_month
+            if hours_per_day is not None
+            else float(hours_per_month)
+        )
+        return NormalizedUsage(
+            days_per_month=days_per_month,
+            hours_per_month=normalized_hours,
+        )
+
+    if mode != "runs_or_monthly":
+        raise ValueError(f"Unsupported usage normalization mode: {mode}")
+
+    runs_per_day = getattr(request, "runs_per_day", None)
+    avg_runtime_minutes = getattr(request, "avg_runtime_minutes", None)
+    has_any_run_param = (
+        runs_per_day is not None or avg_runtime_minutes is not None
+    )
+    has_run_params = (
+        runs_per_day is not None and avg_runtime_minutes is not None
+    )
+
+    if has_any_run_param and not has_run_params:
+        raise HTTPException(status_code=400, detail={
+            "code": "INCOMPLETE_USAGE_PARAMETERS",
+            "message": "runs_per_day and avg_runtime_minutes must be provided together.",
+        })
+    if not has_run_params and hours_per_month is None:
         raise HTTPException(status_code=400, detail={
             "code": "MISSING_USAGE_PARAMETERS",
-            "message": "Must provide either run-based parameters OR hours_per_month",
+            "message": "Must provide either run-based parameters or hours_per_month.",
         })
-    if has_run_params and has_hours:
+    if has_run_params and hours_per_month is not None:
         raise HTTPException(status_code=400, detail={
             "code": "CONFLICTING_USAGE_PARAMETERS",
             "message": "Cannot provide both run-based parameters and hours_per_month.",
         })
-    return has_run_params, has_hours
+    return NormalizedUsage(
+        runs_per_day=runs_per_day or 0,
+        avg_runtime_minutes=avg_runtime_minutes or 0,
+        days_per_month=days_per_month,
+        hours_per_month=(
+            float(hours_per_month) if hours_per_month is not None else None
+        ),
+    )
 
 
 def _validate_classic_inputs(request, db):
@@ -104,9 +157,7 @@ def calculate_jobs_classic_cost(
     request: JobsClassicCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="runs_or_monthly")
 
     _validate_classic_inputs(request, db)
 
@@ -116,10 +167,10 @@ def calculate_jobs_classic_cost(
             "p5": False, "p6": request.photon_enabled, "p7": None,
             "p8": request.driver_node_type, "p9": request.worker_node_type, "p10": request.num_workers,
             "p11": request.driver_pricing_tier, "p12": request.worker_pricing_tier,
-            "p13": request.runs_per_day if has_run_params else 0,
-            "p14": request.avg_runtime_minutes if has_run_params else 0,
-            "p15": request.days_per_month if has_run_params else 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": usage.runs_per_day,
+            "p14": usage.avg_runtime_minutes,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard", "p18": None, "p19": None, "p20": 1, "p21": "on_demand", "p22": None,
             "p23": 0, "p24": None, "p25": None, "p26": None,
             "p27": "global", "p28": "all", "p29": "input_token", "p30": 0, "p31": 0, "p32": 1,
@@ -171,7 +222,7 @@ def calculate_jobs_classic_cost(
                 },
                 "usage": {
                     "runs_per_day": request.runs_per_day, "avg_runtime_minutes": request.avg_runtime_minutes,
-                    "days_per_month": request.days_per_month, "hours_per_month": float(row.hours_per_month or 0),
+                    "days_per_month": usage.days_per_month, "hours_per_month": float(row.hours_per_month or 0),
                 },
                 "dbu_calculation": {
                     "dbu_per_hour": float(row.dbu_per_hour or 0), "dbu_per_month": float(row.dbu_per_month or 0),
@@ -215,9 +266,7 @@ def calculate_jobs_serverless_cost(
     request: JobsServerlessCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="runs_or_monthly")
 
     _validate_serverless_inputs(request, db)
 
@@ -229,10 +278,10 @@ def calculate_jobs_serverless_cost(
             "p8": request.driver_node_type, "p9": request.worker_node_type,
             "p10": request.num_workers or 0,
             "p11": "on_demand", "p12": "on_demand",
-            "p13": request.runs_per_day if has_run_params else 0,
-            "p14": request.avg_runtime_minutes if has_run_params else 0,
-            "p15": request.days_per_month if has_run_params else 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": usage.runs_per_day,
+            "p14": usage.avg_runtime_minutes,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": request.serverless_mode, "p18": None, "p19": None, "p20": 1,
             "p21": "on_demand", "p22": None, "p23": 0, "p24": None, "p25": None, "p26": None,
             "p27": "global", "p28": "all", "p29": "input_token", "p30": 0, "p31": 0, "p32": 1,
@@ -270,7 +319,7 @@ def calculate_jobs_serverless_cost(
                 },
                 "usage": {
                     "runs_per_day": request.runs_per_day, "avg_runtime_minutes": request.avg_runtime_minutes,
-                    "days_per_month": request.days_per_month, "hours_per_month": float(row.hours_per_month or 0),
+                    "days_per_month": usage.days_per_month, "hours_per_month": float(row.hours_per_month or 0),
                 },
                 "dbu_calculation": {
                     "dbu_per_hour": float(row.dbu_per_hour or 0), "dbu_per_month": float(row.dbu_per_month or 0),

--- a/backend/app/routes/calculate/lakeflow_connect_calc.py
+++ b/backend/app/routes/calculate/lakeflow_connect_calc.py
@@ -19,7 +19,7 @@ from app.routes.calculate.helpers import build_sku_breakdown_serverless, build_s
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
 )
-from app.routes.calculate.jobs import _validate_usage_params
+from app.routes.calculate.jobs import normalize_usage_params
 from app.routes.calculate.schemas import LakeflowConnectCalculationRequest
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,8 @@ def calculate_lakeflow_connect_cost(
     request: LakeflowConnectCalculationRequest,
     db: Session = Depends(get_db),
 ):
+    usage = normalize_usage_params(request, mode="runs_or_monthly")
+
     error = validate_cloud(request.cloud)
     if error:
         raise HTTPException(status_code=400, detail=error["error"])
@@ -53,19 +55,15 @@ def calculate_lakeflow_connect_cost(
         tier_upper = request.tier.upper()
 
         # ── Pipeline (DLT Serverless) ─────────────────────────────────
-        has_run_params, has_hours = _validate_usage_params(request, require_runs=False)
-        if has_run_params and request.days_per_month is None:
-            request.days_per_month = 30
-
         params = {
             "p1": "DLT", "p2": cloud_upper, "p3": request.region, "p4": tier_upper,
             "p5": True, "p6": False, "p7": None,
             "p8": None, "p9": None, "p10": 0,
             "p11": "on_demand", "p12": "on_demand",
-            "p13": request.runs_per_day or 0,
-            "p14": request.avg_runtime_minutes or 0,
-            "p15": request.days_per_month or 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p13": usage.runs_per_day,
+            "p14": usage.avg_runtime_minutes,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard", "p18": (request.dlt_edition or "ADVANCED").upper(),
             "p19": None, "p20": 1,
             "p21": "on_demand", "p22": None,

--- a/backend/app/routes/calculate/model_serving_calc.py
+++ b/backend/app/routes/calculate/model_serving_calc.py
@@ -12,7 +12,7 @@ from app.routes.calculate.helpers import build_sku_breakdown_serverless
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
 )
-from app.routes.calculate.jobs import _validate_usage_params
+from app.routes.calculate.jobs import normalize_usage_params
 from app.routes.calculate.schemas import ModelServingCalculationRequest
 
 logger = logging.getLogger(__name__)
@@ -26,9 +26,7 @@ def calculate_model_serving_cost(
     request: ModelServingCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request, require_runs=False)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="daily_or_monthly")
 
     error = validate_cloud(request.cloud)
     if error:
@@ -68,13 +66,7 @@ def calculate_model_serving_cost(
 
         gpu_dbu_rate = float(gpu_row.dbu_rate)
 
-        # Calculate hours
-        if has_hours:
-            hours_per_month = request.hours_per_month
-        else:
-            hours_per_day = getattr(request, 'hours_per_day', None) or 0
-            days_per_month = request.days_per_month or 30
-            hours_per_month = hours_per_day * days_per_month
+        hours_per_month = usage.hours_per_month or 0
 
         # DBU calculation
         dbu_per_hour = gpu_dbu_rate * concurrency

--- a/backend/app/routes/calculate/vector_search_calc.py
+++ b/backend/app/routes/calculate/vector_search_calc.py
@@ -14,7 +14,7 @@ from app.routes.calculate.helpers import build_sku_breakdown_serverless
 from app.routes.calculate.discount import (
     apply_discount_to_sku_breakdown, calculate_total_discount_summary, enhance_total_cost_with_discount,
 )
-from app.routes.calculate.jobs import _validate_usage_params
+from app.routes.calculate.jobs import normalize_usage_params
 from app.routes.calculate.schemas import VectorSearchCalculationRequest
 
 logger = logging.getLogger(__name__)
@@ -26,9 +26,7 @@ def calculate_vector_search_cost(
     request: VectorSearchCalculationRequest,
     db: Session = Depends(get_db),
 ):
-    has_run_params, has_hours = _validate_usage_params(request, require_runs=False)
-    if has_run_params and request.days_per_month is None:
-        request.days_per_month = 30
+    usage = normalize_usage_params(request, mode="daily_or_monthly")
 
     error = validate_cloud(request.cloud)
     if error:
@@ -47,8 +45,8 @@ def calculate_vector_search_cost(
             "p8": None, "p9": None, "p10": 0,
             "p11": "on_demand", "p12": "on_demand",
             "p13": 0, "p14": 0,
-            "p15": request.days_per_month or 30,
-            "p16": int(request.hours_per_month) if has_hours and request.hours_per_month is not None else None,
+            "p15": usage.days_per_month,
+            "p16": usage.hours_per_month,
             "p17": "standard", "p18": None, "p19": None, "p20": 1,
             "p21": "on_demand", "p22": request.mode,
             "p23": request.num_vectors_millions,

--- a/tests/regression/test_hours_per_day_normalization.py
+++ b/tests/regression/test_hours_per_day_normalization.py
@@ -1,0 +1,299 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.routes.calculate import (
+    all_purpose,
+    dbsql_calc,
+    dlt_calc,
+    jobs,
+    lakeflow_connect_calc,
+    vector_search_calc,
+)
+from app.routes.calculate.jobs import normalize_usage_params
+from app.routes.calculate.schemas import (
+    AllPurposeClassicCalculationRequest,
+    AllPurposeServerlessCalculationRequest,
+    DBSQLClassicProCalculationRequest,
+    DBSQLServerlessCalculationRequest,
+    DLTServerlessCalculationRequest,
+    JobsServerlessCalculationRequest,
+    LakeflowConnectCalculationRequest,
+    VectorSearchCalculationRequest,
+)
+
+
+def _calculation_row(params):
+    hours = params["p16"]
+    if hours is None:
+        hours = (
+            params["p13"]
+            * params["p14"]
+            / 60
+            * params["p15"]
+        )
+    dbu_per_hour = 2.0
+    dbu_per_month = dbu_per_hour * hours
+    dbu_price = 0.5
+    dbu_cost = dbu_per_month * dbu_price
+    return SimpleNamespace(
+        hours_per_month=hours,
+        dbu_per_hour=dbu_per_hour,
+        dbu_per_month=dbu_per_month,
+        dbu_price=dbu_price,
+        dbu_cost_per_month=dbu_cost,
+        driver_vm_cost_per_month=0,
+        total_worker_vm_cost_per_month=0,
+        driver_vm_cost_per_hour=0,
+        worker_vm_cost_per_hour=0,
+        total_vm_cost_per_hour=0,
+        vm_cost_per_month=0,
+        cost_per_month=dbu_cost,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_route_dependencies(monkeypatch):
+    for module in (
+        all_purpose,
+        dbsql_calc,
+        dlt_calc,
+        jobs,
+        lakeflow_connect_calc,
+        vector_search_calc,
+    ):
+        monkeypatch.setattr(
+            module,
+            "call_calculate_line_item_costs",
+            lambda _db, params: _calculation_row(params),
+        )
+        monkeypatch.setattr(
+            module,
+            "get_product_type_for_pricing",
+            lambda *_args, **_kwargs: "TEST_SKU",
+        )
+
+    monkeypatch.setattr(
+        all_purpose,
+        "_validate_classic_inputs",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        all_purpose,
+        "_validate_serverless_inputs",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        dlt_calc,
+        "_validate_serverless_inputs",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        jobs,
+        "_validate_serverless_inputs",
+        lambda *_args, **_kwargs: None,
+    )
+
+    for module in (dbsql_calc, lakeflow_connect_calc, vector_search_calc):
+        monkeypatch.setattr(
+            module, "validate_cloud", lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            module, "validate_region", lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            module, "validate_tier", lambda *_args, **_kwargs: None
+        )
+
+    monkeypatch.setattr(
+        dbsql_calc,
+        "validate_warehouse_type",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        dbsql_calc,
+        "validate_warehouse_size",
+        lambda *_args, **_kwargs: None,
+    )
+
+
+DAILY_MONTHLY_CASES = [
+    pytest.param(
+        all_purpose.calculate_all_purpose_classic_cost,
+        AllPurposeClassicCalculationRequest,
+        {
+            "cloud": "AWS",
+            "region": "us-east-1",
+            "tier": "PREMIUM",
+            "driver_node_type": "i3.xlarge",
+            "worker_node_type": "i3.xlarge",
+            "num_workers": 2,
+        },
+        id="all-purpose-classic",
+    ),
+    pytest.param(
+        all_purpose.calculate_all_purpose_serverless_cost,
+        AllPurposeServerlessCalculationRequest,
+        {
+            "cloud": "AWS",
+            "region": "us-east-1",
+            "tier": "PREMIUM",
+        },
+        id="all-purpose-serverless",
+    ),
+    pytest.param(
+        dbsql_calc.calculate_dbsql_classic_pro_cost,
+        DBSQLClassicProCalculationRequest,
+        {
+            "cloud": "AWS",
+            "region": "us-east-1",
+            "tier": "PREMIUM",
+            "warehouse_type": "PRO",
+            "warehouse_size": "Medium",
+        },
+        id="dbsql-classic-pro",
+    ),
+    pytest.param(
+        dbsql_calc.calculate_dbsql_serverless_cost,
+        DBSQLServerlessCalculationRequest,
+        {
+            "cloud": "AWS",
+            "region": "us-east-1",
+            "tier": "PREMIUM",
+            "warehouse_size": "Medium",
+        },
+        id="dbsql-serverless",
+    ),
+    pytest.param(
+        vector_search_calc.calculate_vector_search_cost,
+        VectorSearchCalculationRequest,
+        {
+            "cloud": "AWS",
+            "region": "us-east-1",
+            "tier": "PREMIUM",
+            "mode": "standard",
+            "num_vectors_millions": 2,
+        },
+        id="vector-search",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("calculate", "request_type", "base_payload"),
+    DAILY_MONTHLY_CASES,
+)
+def test_hours_per_day_matches_equivalent_hours_per_month(
+    calculate,
+    request_type,
+    base_payload,
+):
+    daily_request = request_type(
+        **base_payload,
+        hours_per_day=8,
+        days_per_month=30,
+    )
+    monthly_request = request_type(
+        **base_payload,
+        hours_per_month=240,
+    )
+
+    daily_result = calculate(daily_request, db=object())
+    monthly_result = calculate(monthly_request, db=object())
+
+    assert daily_result["success"] is True
+    assert monthly_result["success"] is True
+    assert daily_result["data"]["usage"]["hours_per_month"] == 240
+    assert monthly_result["data"]["usage"]["hours_per_month"] == 240
+    assert daily_result["data"]["total_cost"] == monthly_result["data"]["total_cost"]
+    assert daily_request.hours_per_month is None
+
+
+RUN_USAGE_CASES = [
+    pytest.param(
+        jobs.calculate_jobs_serverless_cost,
+        JobsServerlessCalculationRequest,
+        {},
+        lambda result: result["data"]["usage"]["hours_per_month"],
+        id="jobs-serverless",
+    ),
+    pytest.param(
+        dlt_calc.calculate_dlt_serverless_cost,
+        DLTServerlessCalculationRequest,
+        {"dlt_edition": "ADVANCED"},
+        lambda result: result["data"]["usage"]["hours_per_month"],
+        id="dlt-serverless",
+    ),
+    pytest.param(
+        lakeflow_connect_calc.calculate_lakeflow_connect_cost,
+        LakeflowConnectCalculationRequest,
+        {},
+        lambda result: result["data"]["pipeline"]["hours_per_month"],
+        id="lakeflow-connect",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("calculate", "request_type", "extra_payload", "get_hours"),
+    RUN_USAGE_CASES,
+)
+def test_run_usage_matches_equivalent_monthly_hours(
+    calculate,
+    request_type,
+    extra_payload,
+    get_hours,
+):
+    base_payload = {
+        "cloud": "AWS",
+        "region": "us-east-1",
+        "tier": "PREMIUM",
+        **extra_payload,
+    }
+    run_request = request_type(
+        **base_payload,
+        runs_per_day=2,
+        avg_runtime_minutes=30,
+        days_per_month=20,
+    )
+    monthly_request = request_type(
+        **base_payload,
+        hours_per_month=20,
+    )
+
+    run_result = calculate(run_request, db=object())
+    monthly_result = calculate(monthly_request, db=object())
+
+    assert run_result["success"] is True
+    assert monthly_result["success"] is True
+    assert get_hours(run_result) == 20
+    assert get_hours(monthly_result) == 20
+    assert run_result["data"]["total_cost"] == monthly_result["data"]["total_cost"]
+
+
+def test_daily_and_monthly_inputs_conflict_before_normalization():
+    request = SimpleNamespace(
+        hours_per_day=8,
+        days_per_month=30,
+        hours_per_month=240,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_usage_params(request, mode="daily_or_monthly")
+
+    assert exc_info.value.detail["code"] == "CONFLICTING_USAGE_PARAMETERS"
+
+
+def test_partial_run_inputs_are_rejected():
+    request = SimpleNamespace(
+        runs_per_day=2,
+        avg_runtime_minutes=None,
+        days_per_month=30,
+        hours_per_month=None,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_usage_params(request, mode="runs_or_monthly")
+
+    assert exc_info.value.detail["code"] == "INCOMPLETE_USAGE_PARAMETERS"


### PR DESCRIPTION
## Summary
- validate original run-based, daily, and monthly usage inputs before normalization
- consistently pass normalized monthly hours to All-Purpose, DBSQL, Vector Search, Model Serving, and related calculation routes
- add regression coverage for daily/monthly equivalence, run/monthly equivalence, conflicts, and incomplete run inputs

## Test plan
- [x] `pytest tests/regression/test_hours_per_day_normalization.py -q` — 10 passed
- [x] full regression suite compared with `main` — same pre-existing failures, 10 additional passes
- [x] live API validation on the isolated test app for All-Purpose, DBSQL, Vector Search, and Lakeflow Connect
- [x] manual frontend validation across impacted workloads

Fixes #9