### PR TITLE
Fix release candidate workflow dispatch

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -44,7 +44,7 @@ jobs:
       LAKEMETER_E2E_PROJECT: lm-rc-${{ github.run_id }}
       LAKEMETER_E2E_SCOPE: lm-rc-${{ github.run_id }}
       LAKEMETER_E2E_DB: lakemeter_pricing
-      LAKEMETER_E2E_STATE: ${{ runner.temp }}/lakemeter-release-state.json
+      LAKEMETER_E2E_STATE: ${{ github.workspace }}/lakemeter-release-state.json
 
     steps:
       - name: Check out candidate

--- a/tests/upgrade/test_release_workflow_gate.py
+++ b/tests/upgrade/test_release_workflow_gate.py
@@ -30,6 +30,14 @@ def test_candidate_runs_cross_version_integration_before_tagging():
     assert artifact_position < tag_position
 
 
+def test_candidate_uses_context_available_at_job_initialization():
+    assert "${{ runner.temp }}" not in CANDIDATE_WORKFLOW
+    assert (
+        "LAKEMETER_E2E_STATE: "
+        "${{ github.workspace }}/lakemeter-release-state.json"
+    ) in CANDIDATE_WORKFLOW
+
+
 def test_final_release_only_publishes_matching_tested_artifacts():
     assert "gh run download" in RELEASE_WORKFLOW
     assert "dist/candidate.json" in RELEASE_WORKFLOW


### PR DESCRIPTION
## Summary
- replace the unavailable job-level `runner.temp` context with `github.workspace`
- add regression coverage so the release workflow remains dispatchable

## Test plan
- [x] `python -m pytest tests/upgrade/test_release_workflow_gate.py -q`
- [x] release policy and runtime checksum validation