### PR TITLE
Fix quantity-based Excel recalculation

### DIFF
--- a/backend/app/routes/export/excel_builder.py
+++ b/backend/app/routes/export/excel_builder.py
@@ -298,6 +298,7 @@ def _write_single_item(sheet, fmt, row, idx, item, cloud, region, tier, db=None)
         'cache_read', 'cache_write', 'batch_inference')
     is_fmapi_provisioned = is_fmapi and item.fmapi_rate_type in (
         'provisioned_scaling', 'provisioned_entry')
+    is_quantity_based = wt in ('AI_PARSE', 'SHUTTERSTOCK_IMAGEAI')
 
     auto_notes = list(dbu_warnings)
     if not dbu_rate_found:
@@ -391,6 +392,7 @@ def _write_single_item(sheet, fmt, row, idx, item, cloud, region, tier, db=None)
         'dbu_per_million': dbu_per_m,
         'dbu_per_hour': dbu_per_hour,
         'total_dbus_month': total_dbus,
+        'is_quantity_based': is_quantity_based,
         'dbu_rate': dbu_rate,
         'discount_pct': 0.0,
         'driver_vm_cost_per_hour': driver_vm_hr,

--- a/backend/app/routes/export/excel_row_writer.py
+++ b/backend/app/routes/export/excel_row_writer.py
@@ -83,9 +83,13 @@ def _write_dbu_costs(sheet, row, r, row_data, is_fmapi_token, is_storage_row, fm
     dbu_rate = row_data['dbu_rate']
     discount_pct = row_data['discount_pct']
 
-    # Col 16: DBUs/Mo — FORMULA
+    # Col 16: DBUs/Mo
     if is_storage_row:
         sheet.write(row, 16, 0, fmt['number'])
+    elif row_data.get('is_quantity_based', False):
+        # Quantity workloads have no Hours/Mo × DBU/Hr basis. Writing their
+        # computed DBUs as a value keeps downstream formulas recalculation-safe.
+        sheet.write(row, 16, total_dbus_month, fmt['number'])
     elif is_fmapi_token:
         formula = f'={_col(13)}{r}*{_col(14)}{r}'
         sheet.write_formula(row, 16, formula, fmt['number'], total_dbus_month)

--- a/tests/regression/test_quantity_workload_persistence.py
+++ b/tests/regression/test_quantity_workload_persistence.py
@@ -1,12 +1,23 @@
+from io import BytesIO
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
 
+import openpyxl
 import pytest
 
+from app.routes.export import build_estimate_excel
 from app.routes.export.excel_item_helpers import calc_item_values
 from app.schemas import LineItemCreate, LineItemResponse
 from app.schemas.line_item import map_ai_parse_api_fields
+from tests.regression.conftest import make_item
+from tests.regression.excel_helpers import (
+    COL_DBU_COST_D,
+    COL_DBU_COST_L,
+    COL_DBUS_MO,
+    find_row_by_name,
+    make_estimate,
+)
 
 
 def test_shutterstock_frontend_field_maps_to_storage_and_response():
@@ -65,3 +76,93 @@ def test_excel_uses_canonical_quantity_storage_fields(item, expected_dbus):
     )
 
     assert total_dbus == pytest.approx(expected_dbus)
+
+
+@pytest.mark.parametrize(
+    ("item", "expected_dbus"),
+    [
+        (
+            make_item(
+                workload_type="AI_PARSE",
+                workload_name="AI Parse pages",
+                ai_parse_complexity="medium",
+                ai_parse_num_pages=100_000,
+            ),
+            6_250,
+        ),
+        (
+            make_item(
+                workload_type="SHUTTERSTOCK_IMAGEAI",
+                workload_name="Shutterstock images",
+                shutterstock_imageai_num_images=50_000,
+            ),
+            42_850,
+        ),
+    ],
+)
+def test_quantity_exports_survive_formula_recalculation(item, expected_dbus):
+    output = build_estimate_excel(
+        make_estimate(),
+        [item],
+        cloud="aws",
+        region="us-east-1",
+        tier="PREMIUM",
+    )
+    workbook_bytes = output.getvalue()
+    formulas = openpyxl.load_workbook(
+        BytesIO(workbook_bytes),
+        data_only=False,
+    ).active
+    cached = openpyxl.load_workbook(
+        BytesIO(workbook_bytes),
+        data_only=True,
+    ).active
+
+    row = find_row_by_name(formulas, item.workload_name)
+    assert row is not None
+    assert formulas.cell(row, COL_DBUS_MO).value == pytest.approx(expected_dbus)
+    assert cached.cell(row, COL_DBUS_MO).value == pytest.approx(expected_dbus)
+    assert formulas.cell(row, COL_DBU_COST_L).value == f"=Q{row}*R{row}"
+    assert formulas.cell(row, COL_DBU_COST_D).value == f"=Q{row}*T{row}"
+
+
+@pytest.mark.parametrize(
+    ("item", "expected_columns"),
+    [
+        (
+            make_item(
+                workload_type="JOBS",
+                workload_name="Hourly workload",
+                serverless_enabled=True,
+                serverless_mode="standard",
+                hours_per_month=100,
+            ),
+            ("P", "L"),
+        ),
+        (
+            make_item(
+                workload_type="FMAPI_DATABRICKS",
+                workload_name="Token workload",
+                fmapi_model="llama-3-3-70b",
+                fmapi_rate_type="input_token",
+                fmapi_quantity=100,
+            ),
+            ("N", "O"),
+        ),
+    ],
+)
+def test_non_quantity_exports_keep_live_dbu_formulas(item, expected_columns):
+    output = build_estimate_excel(
+        make_estimate(),
+        [item],
+        cloud="aws",
+        region="us-east-1",
+        tier="PREMIUM",
+    )
+    formulas = openpyxl.load_workbook(output, data_only=False).active
+
+    row = find_row_by_name(formulas, item.workload_name)
+    assert row is not None
+    assert formulas.cell(row, COL_DBUS_MO).value == (
+        f"={expected_columns[0]}{row}*{expected_columns[1]}{row}"
+    )


### PR DESCRIPTION
## Summary
- mark AI Parse and Shutterstock ImageAI exports as quantity-based workloads
- write their calculated DBUs/month as stable numeric values so spreadsheet recalculation cannot collapse costs to zero
- retain live DBU formulas for hourly and FMAPI token workloads, with regression coverage for both paths

## Test plan
- [x] `python -m pytest tests/regression/test_quantity_workload_persistence.py tests/regression/test_formula_values.py tests/export/cross_workload/test_excel_formulas.py -q` — 31 passed
- [x] deployed to `lakemeter-issue7-test` and manually verified AI Parse and Shutterstock exports in Apple Numbers after recalculation
- [ ] full upgrader install/upgrade/rollback validation — deferred until the next patch release is prepared

Fixes #21