### PR TITLE
Fix stale Excel export test expectations

### DIFF
--- a/tests/export/cross_workload/conftest.py
+++ b/tests/export/cross_workload/conftest.py
@@ -51,6 +51,7 @@ def make_jobs_serverless():
     return make_line_item(
         workload_type="JOBS",
         workload_name="Jobs Serverless Perf",
+        driver_node_type="r6g.large",
         serverless_enabled=True,
         serverless_mode="performance",
         hours_per_month=200,
@@ -63,6 +64,8 @@ def make_all_purpose_classic_photon():
     return make_line_item(
         workload_type="ALL_PURPOSE",
         workload_name="All-Purpose Classic Photon",
+        driver_node_type="r6g.large",
+        worker_node_type="r6g.large",
         photon_enabled=True,
         num_workers=2,
         hours_per_month=730,
@@ -75,6 +78,7 @@ def make_dlt_pro_serverless():
     return make_line_item(
         workload_type="DLT",
         workload_name="DLT Pro Serverless",
+        driver_node_type="r6g.large",
         dlt_edition="PRO",
         serverless_enabled=True,
         serverless_mode="standard",

--- a/tests/export/cross_workload/test_combined_calc.py
+++ b/tests/export/cross_workload/test_combined_calc.py
@@ -18,7 +18,7 @@ class TestJobsServerlessCalc:
     def test_dbu_per_hour(self):
         item = make_jobs_serverless()
         dbu, warnings = _calculate_dbu_per_hour(item, 'aws')
-        # base_dbu = 0.5 (driver fallback, matching frontend) + 0 (no workers) = 0.5
+        # base_dbu = 0.5 (r6g.large driver) + 0 (no workers) = 0.5
         # serverless photon multiplier from JSON: *2.9 = 1.45
         # performance: *2 = 2.9
         assert dbu == pytest.approx(2.9, abs=0.01)
@@ -41,7 +41,7 @@ class TestAllPurposeClassicPhotonCalc:
     def test_dbu_per_hour(self):
         item = make_all_purpose_classic_photon()
         dbu, warnings = _calculate_dbu_per_hour(item, 'aws')
-        # base = 0.5 (driver fallback) + 0.5*2 = 1.5, photon *2 = 3.0
+        # base = 0.5 driver + 0.5*2 workers = 1.5, photon *2 = 3.0
         assert dbu == pytest.approx(3.0, abs=0.01)
 
     def test_sku(self):
@@ -61,7 +61,7 @@ class TestDltProServerlessCalc:
     def test_dbu_per_hour(self):
         item = make_dlt_pro_serverless()
         dbu, warnings = _calculate_dbu_per_hour(item, 'aws')
-        # base = 0.5 (driver fallback) + 0 = 0.5, serverless photon from JSON: *2.9 = 1.45, standard *1 = 1.45
+        # base = 0.5 driver, serverless photon *2.9, standard mode *1
         assert dbu == pytest.approx(1.45, abs=0.01)
 
     def test_sku(self):
@@ -164,8 +164,8 @@ class TestLakebaseCalc:
     def test_dbu_per_hour(self):
         item = make_lakebase()
         dbu, warnings = _calculate_dbu_per_hour(item, 'aws')
-        # 4 CU * 2 nodes = 8 DBU/hr
-        assert dbu == pytest.approx(8.0, abs=0.01)
+        # 4 CU × 2 nodes × 0.230 DBU/CU-hour × 75% always-on factor
+        assert dbu == pytest.approx(1.38, abs=0.01)
 
     def test_sku(self):
         item = make_lakebase()

--- a/tests/export/cross_workload/test_dbsql_vm_pricing_export.py
+++ b/tests/export/cross_workload/test_dbsql_vm_pricing_export.py
@@ -1,0 +1,98 @@
+"""Regression tests for DBSQL VM pricing in Excel exports."""
+import pytest
+
+from app.routes.export.excel_builder import _lookup_dbsql_vm_costs
+from tests.export.cross_workload.test_vm_pricing_export import (
+    _PricingDB,
+    _find_row,
+    _load_workbook,
+)
+from tests.export.dbsql.conftest import make_line_item as make_dbsql_item
+
+
+def test_dbsql_lookup_returns_rates_for_selected_payment_option():
+    db = _PricingDB({
+        ("i3.4xlarge", "reserved_3y", "no_upfront"): 0.31,
+        ("i3.2xlarge", "reserved_3y", "no_upfront"): 0.16,
+    })
+    item = make_dbsql_item(
+        dbsql_warehouse_type="CLASSIC",
+        dbsql_warehouse_size="Small",
+        dbsql_vm_pricing_tier="reserved_3y",
+        dbsql_vm_payment_option="no_upfront",
+    )
+    notes = []
+
+    driver_rate, worker_rate, worker_count = _lookup_dbsql_vm_costs(
+        item, "aws", "us-east-1", {}, db, notes
+    )
+
+    assert driver_rate == pytest.approx(0.31)
+    assert worker_rate == pytest.approx(0.16)
+    assert worker_count == 4
+    assert {call["payment_option"] for call in db.calls} == {"no_upfront"}
+    assert notes == []
+
+
+def test_dbsql_export_prefers_current_driver_worker_tiers_over_legacy_tier():
+    db = _PricingDB({
+        ("i3.4xlarge", "on_demand", "na"): 1.248,
+        ("i3.2xlarge", "spot", "na"): 0.3072,
+        ("i3.4xlarge", "reserved_1y", "all_upfront"): 0.75,
+        ("i3.2xlarge", "reserved_1y", "all_upfront"): 0.20,
+    })
+    item = make_dbsql_item(
+        workload_name="DBSQL UI Parity",
+        dbsql_warehouse_type="CLASSIC",
+        dbsql_warehouse_size="Small",
+        hours_per_month=11,
+        driver_pricing_tier="on_demand",
+        driver_payment_option="no_upfront",
+        worker_pricing_tier="spot",
+        worker_payment_option="NA",
+        # Simulate an estimate created before separate driver/worker controls.
+        dbsql_vm_pricing_tier="reserved_1y",
+        dbsql_vm_payment_option="all_upfront",
+    )
+
+    workbook = _load_workbook(item, "aws", "us-east-1", db)
+    sheet = workbook.active
+    row = _find_row(sheet, "DBSQL UI Parity")
+
+    assert sheet.cell(row=row, column=10).value == "On-Demand"
+    assert sheet.cell(row=row, column=11).value == "Spot"
+    assert sheet.cell(row=row, column=27).value == pytest.approx(1.248)
+    assert sheet.cell(row=row, column=28).value == pytest.approx(0.3072)
+    assert sheet.cell(row=row, column=31).value == pytest.approx(27.2448)
+    assert {call["pricing_tier"] for call in db.calls} == {"on_demand", "spot"}
+    workbook.close()
+
+
+def test_dbsql_export_defaults_reserved_worker_na_to_aws_no_upfront():
+    db = _PricingDB({
+        ("i3.4xlarge", "reserved_1y", "no_upfront"): 0.794977,
+        ("i3.2xlarge", "reserved_1y", "no_upfront"): 0.405854,
+    })
+    item = make_dbsql_item(
+        workload_name="DBSQL Reserved UI Parity",
+        dbsql_warehouse_type="CLASSIC",
+        dbsql_warehouse_size="Small",
+        hours_per_month=11,
+        driver_pricing_tier="reserved_1y",
+        driver_payment_option="no_upfront",
+        worker_pricing_tier="reserved_1y",
+        # Reproduces the stale value saved while the UI displayed No Upfront.
+        worker_payment_option="NA",
+    )
+
+    workbook = _load_workbook(item, "aws", "us-east-1", db)
+    sheet = workbook.active
+    row = _find_row(sheet, "DBSQL Reserved UI Parity")
+
+    assert sheet.cell(row=row, column=10).value == "1-Year Reserved"
+    assert sheet.cell(row=row, column=11).value == "1-Year Reserved"
+    assert sheet.cell(row=row, column=27).value == pytest.approx(0.794977)
+    assert sheet.cell(row=row, column=28).value == pytest.approx(0.405854)
+    assert sheet.cell(row=row, column=31).value == pytest.approx(26.602323)
+    assert {call["payment_option"] for call in db.calls} == {"no_upfront"}
+    workbook.close()

--- a/tests/export/cross_workload/test_excel_structure.py
+++ b/tests/export/cross_workload/test_excel_structure.py
@@ -134,7 +134,7 @@ class TestDbuPerHour:
     def test_jobs_dbu_hr(self, ws):
         row = find_row_by_name(ws, 'Jobs Serverless Perf')
         val = ws.cell(row=row, column=COL_DBU_HR).value
-        # base=0.5 (driver fallback), photon 2.9 from JSON, performance *2 = 2.9
+        # base=0.5 driver, photon 2.9 from JSON, performance *2 = 2.9
         assert val == pytest.approx(2.9, abs=0.01)
 
     def test_all_purpose_dbu_hr(self, ws):
@@ -151,7 +151,7 @@ class TestDbuPerHour:
     def test_lakebase_dbu_hr(self, ws):
         row = find_row_by_name(ws, 'Lakebase 4CU 2HA')
         val = ws.cell(row=row, column=COL_DBU_HR).value
-        assert val == pytest.approx(8.0, abs=0.01)
+        assert val == pytest.approx(1.38, abs=0.01)
 
     def test_model_serving_dbu_hr(self, ws):
         """Model Serving GPU (A10G x1) should show 20.0 DBU/hr."""

--- a/tests/export/cross_workload/test_pricing_lookups.py
+++ b/tests/export/cross_workload/test_pricing_lookups.py
@@ -78,7 +78,13 @@ class TestMultiCloudPricing:
 
     def test_jobs_all_clouds_no_warnings(self):
         item = make_jobs_serverless()
-        for cloud in ('aws', 'azure', 'gcp'):
+        node_types = {
+            'aws': 'r6g.large',
+            'azure': 'Standard_E2_v3',
+            'gcp': 'n2-highmem-2',
+        }
+        for cloud, node_type in node_types.items():
+            item.driver_node_type = node_type
             _, warnings = _calculate_dbu_per_hour(item, cloud)
             assert len(warnings) == 0, f"Jobs {cloud}: {warnings}"
 

--- a/tests/export/cross_workload/test_vm_pricing_export.py
+++ b/tests/export/cross_workload/test_vm_pricing_export.py
@@ -6,12 +6,8 @@ from types import SimpleNamespace
 import openpyxl
 import pytest
 
-from app.routes.export.excel_builder import (
-    _lookup_dbsql_vm_costs,
-    build_estimate_excel,
-)
+from app.routes.export.excel_builder import build_estimate_excel
 from tests.export.all_purpose.conftest import make_line_item as make_all_purpose_item
-from tests.export.dbsql.conftest import make_line_item as make_dbsql_item
 from tests.export.dlt.conftest import make_line_item as make_dlt_item
 from tests.export.jobs.conftest import make_line_item as make_jobs_item
 
@@ -144,92 +140,4 @@ def test_missing_azure_spot_rate_is_not_synthetically_discounted():
     assert sheet.cell(row=row, column=27).value == pytest.approx(0.293)
     assert sheet.cell(row=row, column=28).value == pytest.approx(0.293)
     assert "conservative fallback" in sheet.cell(row=row, column=34).value
-    workbook.close()
-
-
-def test_dbsql_lookup_returns_rates_for_selected_payment_option():
-    db = _PricingDB({
-        ("i3.4xlarge", "reserved_3y", "no_upfront"): 0.31,
-        ("i3.2xlarge", "reserved_3y", "no_upfront"): 0.16,
-    })
-    item = make_dbsql_item(
-        dbsql_warehouse_type="CLASSIC",
-        dbsql_warehouse_size="Small",
-        dbsql_vm_pricing_tier="reserved_3y",
-        dbsql_vm_payment_option="no_upfront",
-    )
-    notes = []
-
-    driver_rate, worker_rate, worker_count = _lookup_dbsql_vm_costs(
-        item, "aws", "us-east-1", {}, db, notes
-    )
-
-    assert driver_rate == pytest.approx(0.31)
-    assert worker_rate == pytest.approx(0.16)
-    assert worker_count == 4
-    assert {call["payment_option"] for call in db.calls} == {"no_upfront"}
-    assert notes == []
-
-
-def test_dbsql_export_prefers_current_driver_worker_tiers_over_legacy_tier():
-    db = _PricingDB({
-        ("i3.4xlarge", "on_demand", "na"): 1.248,
-        ("i3.2xlarge", "spot", "na"): 0.3072,
-        ("i3.4xlarge", "reserved_1y", "all_upfront"): 0.75,
-        ("i3.2xlarge", "reserved_1y", "all_upfront"): 0.20,
-    })
-    item = make_dbsql_item(
-        workload_name="DBSQL UI Parity",
-        dbsql_warehouse_type="CLASSIC",
-        dbsql_warehouse_size="Small",
-        hours_per_month=11,
-        driver_pricing_tier="on_demand",
-        driver_payment_option="no_upfront",
-        worker_pricing_tier="spot",
-        worker_payment_option="NA",
-        # Simulate an estimate created before separate driver/worker controls.
-        dbsql_vm_pricing_tier="reserved_1y",
-        dbsql_vm_payment_option="all_upfront",
-    )
-
-    workbook = _load_workbook(item, "aws", "us-east-1", db)
-    sheet = workbook.active
-    row = _find_row(sheet, "DBSQL UI Parity")
-
-    assert sheet.cell(row=row, column=10).value == "On-Demand"
-    assert sheet.cell(row=row, column=11).value == "Spot"
-    assert sheet.cell(row=row, column=27).value == pytest.approx(1.248)
-    assert sheet.cell(row=row, column=28).value == pytest.approx(0.3072)
-    assert sheet.cell(row=row, column=31).value == pytest.approx(27.2448)
-    assert {call["pricing_tier"] for call in db.calls} == {"on_demand", "spot"}
-    workbook.close()
-
-
-def test_dbsql_export_defaults_reserved_worker_na_to_aws_no_upfront():
-    db = _PricingDB({
-        ("i3.4xlarge", "reserved_1y", "no_upfront"): 0.794977,
-        ("i3.2xlarge", "reserved_1y", "no_upfront"): 0.405854,
-    })
-    item = make_dbsql_item(
-        workload_name="DBSQL Reserved UI Parity",
-        dbsql_warehouse_type="CLASSIC",
-        dbsql_warehouse_size="Small",
-        hours_per_month=11,
-        driver_pricing_tier="reserved_1y",
-        driver_payment_option="no_upfront",
-        worker_pricing_tier="reserved_1y",
-        # Reproduces the stale value saved while the UI displayed No Upfront.
-        worker_payment_option="NA",
-    )
-
-    workbook = _load_workbook(item, "aws", "us-east-1", db)
-    sheet = workbook.active
-    row = _find_row(sheet, "DBSQL Reserved UI Parity")
-
-    assert sheet.cell(row=row, column=10).value == "1-Year Reserved"
-    assert sheet.cell(row=row, column=11).value == "1-Year Reserved"
-    assert sheet.cell(row=row, column=27).value == pytest.approx(0.794977)
-    assert sheet.cell(row=row, column=28).value == pytest.approx(0.405854)
-    assert sheet.cell(row=row, column=31).value == pytest.approx(26.602323)
-    assert {call["payment_option"] for call in db.calls} == {"no_upfront"}
     workbook.close()

--- a/tests/export/jobs/test_jobs_vm_and_notes.py
+++ b/tests/export/jobs/test_jobs_vm_and_notes.py
@@ -271,26 +271,24 @@ class TestNoNaNOrZeroCosts:
 # ============================================================
 
 class TestLakebaseDBUFormula:
-    """Lakebase DBU/hr = CU × HA nodes.
-    BUG-S1-6 fixed: backend previously used cu×nodes×2, now aligned with frontend.
-    """
+    """Lakebase equivalent DBU/hr includes regional rate and discount."""
 
     def test_lakebase_backend_formula(self):
-        """Backend: DBU/hr = CU × nodes (fixed — was cu×nodes×2)."""
+        """AWS Premium always-on usage applies its 25% baseline discount."""
         item = make_line_item(
             workload_type="LAKEBASE",
             lakebase_cu=4, lakebase_ha_nodes=2, lakebase_storage_gb=100,
         )
         dbu_hr, _ = _calculate_dbu_per_hour(item, "aws")
-        # Correct formula: 4 × 2 = 8
-        assert dbu_hr == pytest.approx(8.0), \
-            f"Backend Lakebase DBU/hr should be cu×nodes = 8, got {dbu_hr}"
+        expected = 4 * 2 * 0.230 * 0.75
+        assert dbu_hr == pytest.approx(expected)
 
     def test_lakebase_single_node(self):
-        """0.5 CU × 1 node = 0.5 DBU/hr."""
+        """Half-CU single-node usage applies the regional effective rate."""
         item = make_line_item(
             workload_type="LAKEBASE",
             lakebase_cu=0.5, lakebase_ha_nodes=1,
         )
         dbu_hr, _ = _calculate_dbu_per_hour(item, "aws")
-        assert dbu_hr == pytest.approx(0.5)
+        expected = 0.5 * 1 * 0.230 * 0.75
+        assert dbu_hr == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- give cross-workload compute fixtures valid cloud instance types so they exercise current DBU calculations instead of accidental zero/fallback behavior
- align Lakebase assertions with the regional DBU-per-CU rate and always-on baseline discount
- split DBSQL VM pricing tests into a focused module to preserve the existing 200-line test-file guard

## Test plan
- [x] Focused updated regression tests: 59 passed
- [x] Broad Excel export suites: 802 passed
- [x] No lint or whitespace errors