### PR TITLE
Document v0.3 workloads and pricing behavior

### DIFF
--- a/docs-site/docs/admin-guide/api-reference.md
+++ b/docs-site/docs/admin-guide/api-reference.md
@@ -253,7 +253,7 @@ All calculation endpoints accept workload parameters and return cost breakdowns.
 | `POST /api/v1/calculate/model-serving` | Model Serving |
 | `POST /api/v1/calculate/fmapi-databricks` | FMAPI (Databricks-hosted) |
 | `POST /api/v1/calculate/fmapi-proprietary` | FMAPI (Proprietary) |
-| `POST /api/v1/calculate/vector-search` | AI Search (legacy route retained for compatibility) |
+| `POST /api/v1/calculate/vector-search` | AI Search (the route key remains `vector-search`) |
 | `POST /api/v1/calculate/lakebase` | Lakebase |
 | `POST /api/v1/calculate/databricks-apps` | Databricks Apps |
 | `POST /api/v1/calculate/general-storage` | Databricks Default Storage (DSU-based) |

--- a/docs-site/docs/admin-guide/api-reference.md
+++ b/docs-site/docs/admin-guide/api-reference.md
@@ -249,12 +249,16 @@ All calculation endpoints accept workload parameters and return cost breakdowns.
 | `POST /api/v1/calculate/dbsql-serverless` | DBSQL (Serverless) |
 | `POST /api/v1/calculate/dlt-classic` | DLT (Classic) |
 | `POST /api/v1/calculate/dlt-serverless` | DLT (Serverless) |
+| `POST /api/v1/calculate/lakeflow-connect` | Lakeflow Connect pipeline and optional gateway |
 | `POST /api/v1/calculate/model-serving` | Model Serving |
 | `POST /api/v1/calculate/fmapi-databricks` | FMAPI (Databricks-hosted) |
 | `POST /api/v1/calculate/fmapi-proprietary` | FMAPI (Proprietary) |
 | `POST /api/v1/calculate/vector-search` | AI Search (legacy route retained for compatibility) |
 | `POST /api/v1/calculate/lakebase` | Lakebase |
 | `POST /api/v1/calculate/databricks-apps` | Databricks Apps |
+| `POST /api/v1/calculate/general-storage` | Databricks Default Storage (DSU-based) |
+| `POST /api/v1/calculate/zerobus` | Standard or OTel Zerobus ingestion |
+| `POST /api/v1/calculate/platform-addon` | Estimate-level Platform Add-on uplift |
 | `POST /api/v1/calculate/ai-parse` | AI Parse (Document AI) |
 | `POST /api/v1/calculate/ai-extract` | AI Extract (raw `STRING` or parsed document input) |
 | `POST /api/v1/calculate/ai-classify` | AI Classify (raw `STRING` or parsed document input) |
@@ -302,7 +306,47 @@ All calculation endpoints accept workload parameters and return cost breakdowns.
   "region": "us-east-1",
   "tier": "PREMIUM",
   "size": "medium",
+  "num_apps": 3,
   "hours_per_month": 730
+}
+```
+
+### Example: Databricks Default Storage
+
+```json
+{
+  "cloud": "AWS",
+  "region": "us-east-1",
+  "tier": "PREMIUM",
+  "quantity": 1024,
+  "unit": "gb",
+  "tier_1_operations_thousands": 100,
+  "tier_2_operations_thousands": 500
+}
+```
+
+### Example: Zerobus
+
+```json
+{
+  "cloud": "AWS",
+  "region": "us-east-1",
+  "tier": "PREMIUM",
+  "mode": "otel",
+  "monthly_ingested_gb": 1000
+}
+```
+
+### Example: Platform Add-on
+
+```json
+{
+  "cloud": "AWS",
+  "tier": "ENTERPRISE",
+  "addon_type": "MISSION_CRITICAL",
+  "product_spend_at_list": 10000,
+  "pricing_date": "2026-08-30",
+  "discount_pct": 0
 }
 ```
 
@@ -491,7 +535,9 @@ PUT /api/v1/users/{user_id}
 GET /api/v1/workload-types
 ```
 
-Returns all 14 workload types with their UI configuration flags.
+Returns the workload types present in the installation's reference data with
+their UI configuration flags. The exact set depends on the installed release
+and completed data updates.
 
 ### Get Workload Type
 
@@ -804,7 +850,7 @@ Basic process health check:
 ```json
 {
   "status": "healthy",
-  "version": "0.1.2"
+  "version": "0.3.0"
 }
 ```
 
@@ -820,7 +866,7 @@ Version response:
 
 ```json
 {
-  "app_version": "0.1.2",
+  "app_version": "0.3.0",
   "upgrade_policy": {
     "patch": "code_only",
     "minor": "data_update",
@@ -834,7 +880,7 @@ System health response:
 ```json
 {
   "status": "healthy",
-  "app_version": "0.1.2",
+  "app_version": "0.3.0",
   "database": "connected"
 }
 ```

--- a/docs-site/docs/admin-guide/upgrading.md
+++ b/docs-site/docs/admin-guide/upgrading.md
@@ -27,11 +27,13 @@ Lakemeter uses the following release policy:
   migrations, optionally followed by data updates. The upgrader creates a
   Lakebase backup branch first.
 
-Database release lines cannot be skipped. For example, upgrade through a
-required `0.2.x` data release before moving to `0.3.0`.
+Whether a release can be installed directly is defined by its release
+manifest. Always review the `minimum_version` and the actions shown by
+`upgrade.sh plan`.
 
-The `v0.1.2` release supports direct code-only upgrades from both `v0.1.0` and
-`v0.1.1`.
+The `v0.3.0` manifest supports direct upgrades from `v0.1.0` and later. It
+creates a Lakebase backup branch, applies data updates `020` through `027`, and
+does not run a schema migration.
 
 ## Prerequisites
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -12,6 +12,44 @@ Lakemeter follows [Semantic Versioning](https://semver.org/):
 
 ---
 
+## v0.3.0
+
+*Unreleased*
+
+Data and application release expanding workload coverage, DSU accounting, estimate-level add-ons, and cross-surface calculation parity. The release includes reference-data updates but no Lakebase schema migration.
+
+### New workload coverage
+
+- Added AI Extract and AI Classify quantity-based estimates
+- Added Unity AI Gateway inference-table and usage-tracking estimates
+- Added Agent Evaluation labels, token, and synthetic-question estimates
+- Added AI Runtime serverless GPU training for AWS and Azure
+- Added Databricks Default Storage with stored-data and Tier 1 and Tier 2 operation DSUs
+- Added standard and OpenTelemetry Zerobus ingestion using Jobs Serverless DBUs
+- Refreshed Databricks and proprietary Foundation Model API catalogs
+
+### Platform and export enhancements
+
+- Added Enhanced Security and Compliance and Mission Critical Platform Add-ons, calculated from DBU and DSU Product Spend at List
+- Added first-class DSU totals and regional `DATABRICKS_STORAGE` pricing
+- Expanded Excel exports to 34 columns with DSU costs, a pre-add-on workload summary, a Platform Add-on section, and a final estimate summary
+- Added AI Search reranker pricing and aligned AI Search and Lakebase storage with DSU-based calculations
+
+### Calculation fixes
+
+- Fixed All-Purpose Serverless rate parity
+- Fixed saved always-on workloads so the UI, calculation APIs, and Excel consistently resolve missing usage to 730 hours
+- Fixed Databricks Apps counts so multiple apps multiply DBUs and cost across the API, UI, and Excel
+- Preserved explicit zero hours and run-based usage precedence
+
+### Upgrade notes
+
+- Applies data updates `020` through `027` for the new workload reference entries
+- Does not add or alter Lakebase columns
+- Use the [Upgrade Guide](./admin-guide/upgrading.md) to validate and apply the release from a clean checkout
+
+---
+
 ## v0.1.2
 
 *2026-08-08*

--- a/docs-site/docs/testing/integration-validation-tests.md
+++ b/docs-site/docs/testing/integration-validation-tests.md
@@ -63,7 +63,7 @@ Live integration tests that verify the SP OAuth flow end-to-end. These tests are
 | Full SP OAuth flow | Token generation -> DB connection -> query execution |
 | Token reuse | Same token works across multiple connections |
 | App health endpoint | `GET /health` returns 200 with `status: healthy` |
-| Pricing data access | All 14 workload types readable, names match expected set |
+| Pricing data access | Installed reference workload types are readable and match the expected set for the release |
 | DBU rates populated | DBU rate values are present and > 0 |
 
 ### `test_cross_feature_consistency.py` (41 tests)

--- a/docs-site/docs/testing/overview.md
+++ b/docs-site/docs/testing/overview.md
@@ -4,7 +4,10 @@ sidebar_position: 1
 
 # Test Suite Overview
 
-Lakemeter includes a comprehensive end-to-end test harness that validates the AI assistant's ability to interpret natural language requests and produce correct workload configurations for all 14 supported workload types.
+Lakemeter includes end-to-end, regression, parity, and export tests for its
+supported workload types. Coverage expands as workloads are added, so the test
+suite and current workload catalog are the source of truth rather than a fixed
+workload count.
 
 ## Purpose
 

--- a/docs-site/docs/user-guide/ai-parse.md
+++ b/docs-site/docs/user-guide/ai-parse.md
@@ -4,7 +4,7 @@ sidebar_position: 17
 
 # AI Parse Sizing
 
-> **Lakemeter UI name:** AI Parse
+> **Lakemeter UI name:** AI Parse (Document AI)
 
 Use this guide to model monthly AI Parse page-processing consumption in Lakemeter. It explains the estimator inputs and calculation behavior, not document-processing capabilities, supported formats, or product limits.
 

--- a/docs-site/docs/user-guide/calculation-reference.md
+++ b/docs-site/docs/user-guide/calculation-reference.md
@@ -47,6 +47,11 @@ Use run-based inputs when the workload executes a predictable number of times.
 
 Enter the expected billable hours for the month. Use representative operating time rather than the total hours in a month unless the workload is intentionally modeled as always on.
 
+When hours are omitted, AI Search, Model Serving, Lakebase, Databricks Apps,
+and the Lakeflow Connect calculation path default to 730 hours. Run-based
+usage takes precedence over direct hours; an explicitly stored value of zero
+is preserved.
+
 ### Quantity-based usage
 
 Some workloads are sized by tokens, pages, images, storage, vectors, or another billing quantity:

--- a/docs-site/docs/user-guide/calculation-reference.md
+++ b/docs-site/docs/user-guide/calculation-reference.md
@@ -15,7 +15,7 @@ Most estimates follow four steps:
 1. Convert the workload inputs into a monthly billing quantity.
 2. Resolve the applicable SKU and list rate for the estimate context.
 3. Multiply the billing quantity by the rate.
-4. Add any separately modeled VM, storage, or direct-cost components.
+4. Add any separately modeled VM, DSU, or direct-cost components.
 
 The expanded calculation in the Lakemeter UI shows the actual inputs, quantities, and rates used for a saved workload.
 
@@ -87,6 +87,20 @@ A workload can contain more than one billable component. For example, compute, s
 
 Review every subcomponent rather than treating the first row as the complete workload total.
 
+## DSU-based calculations
+
+Databricks-managed storage is represented in Databricks Storage Units:
+
+```text
+Monthly DSUs = Storage or operation quantity × Workload DSU multiplier
+
+DSU cost = Monthly DSUs × Regional DATABRICKS_STORAGE price per DSU
+```
+
+Databricks Default Storage uses DSUs for stored data and Tier 1 and Tier 2 operations. AI Search uses DSUs for billable storage above its included allowance. Lakebase uses separate DSU multipliers for database storage, point-in-time restore, and snapshots.
+
+DSU costs remain separate from DBU compute and cloud VM infrastructure in the expanded calculation and Excel export.
+
 ## Discounts
 
 Lakemeter starts with the list rate loaded for the selected estimate context. A standard percentage discount is modeled as:
@@ -100,6 +114,20 @@ Some workload calculations can include a workload-specific pricing adjustment be
 
 Discounts in Lakemeter are planning assumptions. Confirm eligibility and actual contract pricing separately.
 
+## Platform Add-ons
+
+Platform Add-ons are calculated after workload list costs are known:
+
+```text
+Product Spend at List = DBU list cost + DSU list cost
+
+Add-on cost = Product Spend at List × Active uplift percentage
+```
+
+VM infrastructure and the add-on itself are excluded from Product Spend at List. Workload discounts do not reduce the base. A separate negotiated add-on discount can be applied after the uplift.
+
+See [Platform Add-ons](./platform-addons) for eligibility, promotions, and Excel behavior.
+
 ## Rate lookup
 
 The estimate context identifies the cloud, region, and pricing tier. Lakemeter then resolves the applicable rate for the selected SKU from its pricing data.
@@ -112,12 +140,16 @@ Use the [Workload Sizing Guides](./workloads) for the canonical calculation beha
 
 - [Jobs Compute](./jobs-compute) — run-based compute, workers, DBUs, and VM costs
 - [Databricks SQL](./dbsql-warehouses) — warehouse size, clusters, hours, and mode
-- [FMAPI — Databricks](./fmapi-databricks) — token or provisioned quantities
-- [FMAPI — Proprietary](./fmapi-proprietary) — model, geography, context, and token quantities
+- [Foundation Models — Databricks](./fmapi-databricks) — token or provisioned quantities
+- [Foundation Models — Proprietary](./fmapi-proprietary) — model, geography, context, and token quantities
 - [Lakebase](./lakebase) — minimum and scale-up compute, nodes, storage, PITR, and snapshots
 - [Unity AI Gateway](./ai-gateway) — independent components, request or direct payload input, DBUs per GB
 - [Agent Evaluation](./agent-evaluation) — independent components, evaluation tokens and synthetic questions
 - [AI Runtime](./ai-runtime) — accelerator GPU count, GPU-hours, and the `MODEL_TRAINING` SKU
+- [Databricks Default Storage](./general-storage) — stored data and operation quantities converted to DSUs
+- [Zerobus Ingest](./zerobus) — standard or OTel ingestion volume converted to Jobs Serverless DBUs
+- [Databricks Apps](./databricks-apps) — app size, app count, and active hours
+- [Platform Add-ons](./platform-addons) — estimate-level uplift on DBU and DSU Product Spend at List
 
 ## Validate an estimate
 

--- a/docs-site/docs/user-guide/creating-estimates.md
+++ b/docs-site/docs/user-guide/creating-estimates.md
@@ -20,6 +20,7 @@ An estimate is the top-level container for your Databricks cost analysis. Each e
 | **Cloud** | Yes | Deployment provider selected from the options shown |
 | **Region** | Yes | Deployment region (options depend on selected cloud) |
 | **Tier** | Yes | Pricing tier selected from the available options |
+| **Platform Add-on** | No | Estimate-level Enhanced Security and Compliance or Mission Critical uplift, when available for the selected cloud and tier |
 
 ## Creating a New Estimate
 
@@ -32,6 +33,11 @@ You'll be redirected to the calculator page where you can start adding workloads
 
 ![Calculator page with workloads and cost summary](/img/calculator-overview.png)
 *After creating an estimate, the calculator page is where you add and configure workloads.*
+
+Select a Platform Add-on on the calculator page after choosing the cloud and
+tier. The selection applies to the whole estimate rather than an individual
+workload. See [Platform Add-ons](./platform-addons) for eligibility and cost
+calculation details.
 
 ## Managing Estimates
 
@@ -51,12 +57,16 @@ Click on any estimate to open it in the calculator. You can:
 - Update the estimate name, region, or tier
 - Add, edit, or remove workloads
 - Reorder workloads by dragging
+- Select or clear an eligible Platform Add-on
 
 ![Drag and drop to reorder workloads in the estimate](/img/gifs/drag-and-drop.gif)
 *Animated: drag workloads to reorder them — the display order updates instantly.*
 
 :::caution
 Changing the **cloud provider** is blocked if the estimate already has workloads, since pricing and available instance types differ between clouds.
+
+Changing cloud or tier clears a Platform Add-on selection when it is no longer
+eligible for the updated estimate.
 :::
 
 ### Duplicating an Estimate

--- a/docs-site/docs/user-guide/creating-estimates.md
+++ b/docs-site/docs/user-guide/creating-estimates.md
@@ -20,7 +20,6 @@ An estimate is the top-level container for your Databricks cost analysis. Each e
 | **Cloud** | Yes | Deployment provider selected from the options shown |
 | **Region** | Yes | Deployment region (options depend on selected cloud) |
 | **Tier** | Yes | Pricing tier selected from the available options |
-| **Platform Add-on** | No | Estimate-level Enhanced Security and Compliance or Mission Critical uplift, when available for the selected cloud and tier |
 
 ## Creating a New Estimate
 
@@ -76,7 +75,7 @@ To create a copy of an existing estimate:
 1. Open the estimate
 2. Click **Duplicate**
 
-The copy includes all workloads and their configurations. The new estimate is named with a "(Copy)" suffix.
+The copy includes all workloads, discount configuration, and any Platform Add-on selection. The new estimate is named with a "(Copy)" suffix.
 
 ### Deleting an Estimate
 

--- a/docs-site/docs/user-guide/databricks-apps.md
+++ b/docs-site/docs/user-guide/databricks-apps.md
@@ -18,9 +18,15 @@ Select the app size that represents the workload. The selected size determines t
 
 Use the options shown in Lakemeter rather than copying an option inventory or conversion values from this guide. Confirm the appropriate size using current Databricks guidance and your own workload testing.
 
+### Number of Apps
+
+Enter the number of identically sized apps that use the same monthly schedule. Each app is billed independently, so this value multiplies the DBU consumption.
+
+Create separate workload entries when apps use different sizes or operating schedules.
+
 ### Hours Per Month
 
-Enter the expected billed uptime for one app for one month.
+Enter the expected billed uptime per app for one month.
 
 For a schedule-based estimate:
 
@@ -30,13 +36,15 @@ Hours per month
   × Active days per month
 ```
 
-A workload entry models one app. Create a separate workload entry for each additional app, including apps that share the same size or schedule.
-
 ## Expected monthly quantity
 
-The monthly quantity is **app-hours for one app**. Base it on the expected operating schedule rather than request count or user count.
+The monthly quantity is aggregate app-hours. Base it on the expected operating schedule rather than request count or user count.
 
-Include every period that should be represented as billed uptime. Estimate each app separately so its size and schedule remain reviewable.
+```text
+Aggregate app-hours = Number of apps × Hours per app
+```
+
+Include every period that should be represented as billed uptime. Group apps only when their size and schedule are the same.
 
 ## How Lakemeter calculates cost
 
@@ -44,7 +52,8 @@ Lakemeter resolves the DBU-per-hour conversion for the selected app size and the
 
 ```text
 Monthly DBUs
-  = App hours per month
+  = Number of apps
+  × App hours per month
   × DBU per app-hour for the selected size
 
 Monthly cost
@@ -59,15 +68,15 @@ This Lakemeter workload model does not add a separate VM infrastructure charge.
 ## What to review before saving
 
 - Does the selected app size match the option intended for the workload?
+- Does the app count include every identically configured app?
 - Do monthly hours represent billed uptime rather than only periods of user activity?
-- Does this workload entry represent only one app?
-- Are additional apps and environments modeled as separate workload entries?
+- Are apps with different sizes or schedules modeled as separate workload entries?
 - Does the estimate use the intended cloud, region, and pricing tier?
 - Do the conversion and DBU price shown in Lakemeter match the current pricing source?
 
 ## Excel export
 
-Each Databricks Apps workload is exported as one row for one app. The row includes the selected size, monthly hours, DBU conversion, monthly DBUs, applicable DBU rates, and calculated list and discounted costs.
+Each Databricks Apps workload is exported as one row. The configuration includes the selected size and app count. The row's DBU-per-hour value is the aggregate rate across all apps and is multiplied by monthly hours to calculate monthly DBUs.
 
 Use the exported configuration and hours to trace the cost back to the workload assumptions. The VM cost fields remain zero because this Lakemeter workload model calculates the entry from DBU consumption only.
 

--- a/docs-site/docs/user-guide/databricks-apps.md
+++ b/docs-site/docs/user-guide/databricks-apps.md
@@ -28,6 +28,8 @@ Create separate workload entries when apps use different sizes or operating sche
 
 Enter the expected billed uptime per app for one month.
 
+If hours are omitted, Lakemeter models the apps as always on for 730 hours per month.
+
 For a schedule-based estimate:
 
 ```text

--- a/docs-site/docs/user-guide/dlt-pipelines.md
+++ b/docs-site/docs/user-guide/dlt-pipelines.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 # Lakeflow Spark Declarative Pipelines (SDP) Sizing
 
-> **Lakemeter UI name:** Lakeflow Spark Declarative Pipelines (SDP)
+> **Lakemeter UI name:** Lakeflow Spark Declarative Pipelines
 
 Use this guide to model Lakeflow Spark Declarative Pipelines (SDP) compute consumption in Lakemeter. It explains the estimator inputs and calculation behavior, not pipeline design, edition features, performance tuning, or product limits.
 

--- a/docs-site/docs/user-guide/end-to-end-workflow.md
+++ b/docs-site/docs/user-guide/end-to-end-workflow.md
@@ -68,24 +68,27 @@ Costs update in real-time as you adjust parameters.
 
 The Calculator page displays:
 
-- **Per-workload costs** -- Monthly cost for each workload, broken down into DBU costs and VM infrastructure costs (where applicable).
-- **Total estimate** -- Sum of all workloads displayed at the top.
-- **DBU consumption** -- Total Databricks Units consumed per month by each workload.
+- **Per-workload costs** -- Monthly DBU, DSU, and VM infrastructure costs where applicable.
+- **Platform Add-on** -- Estimate-level uplift on DBU and DSU Product Spend at List, excluding VM cost.
+- **Total estimate** -- Workloads after discounts plus the selected Platform Add-on.
+- **DBU and DSU consumption** -- Monthly Databricks compute and storage units.
 
 **Understanding the cost components:**
 
 | Component | What to verify |
 |-----------|----------------|
 | **DBU cost** | Monthly DBU quantity, selected SKU, and list rate |
+| **DSU cost** | Monthly DSU quantity, component multiplier, and regional `DATABRICKS_STORAGE` rate |
 | **VM cost** | Instance choice, scale-out count, purchasing assumption, and active hours |
 | **Quantity-based cost** | Token, page, image, or other monthly billing quantity |
-| **Storage cost** | Storage quantity and any separately modeled protection or overflow component |
+| **Platform Add-on** | Product Spend at List, eligibility, active uplift, promotion, and separate add-on discount |
+| **Grand total** | Workloads after discounts plus the add-on after discount |
 
-Use each workload's sizing guide for its calculation details. Use the official Databricks documentation for product optimization guidance.
+Use each workload's sizing guide for its calculation details. See [Platform Add-ons](./platform-addons) for estimate-level uplift behavior. Use the official Databricks documentation for product optimization guidance.
 
 ## 5. Export to Excel
 
-1. Click the **Export** button (download icon) at the top of the Calculator page.
+1. Click the **Excel** button (download icon) at the top of the Calculator page.
 2. The file downloads as `Databricks_Estimate_{name}_{date}.xlsx`.
 
 You can also export all your estimates at once from the home page using the bulk export option.

--- a/docs-site/docs/user-guide/exporting.md
+++ b/docs-site/docs/user-guide/exporting.md
@@ -14,7 +14,7 @@ Lakemeter exports your estimates to professionally formatted Excel spreadsheets 
 ### Single Estimate
 
 1. Open the estimate you want to export
-2. Click the **Export** button (download arrow icon) in the top bar
+2. Click the **Excel** button (download arrow icon) in the top bar
 3. An `.xlsx` file downloads automatically
 
 **File name format:** `Databricks_Estimate_{estimate_name}_{YYYYMMDD}.xlsx`
@@ -40,14 +40,14 @@ Each workload in your estimate produces a primary row. Workloads with separately
 
 | Group | Columns | What's there |
 |-------|---------|-------------|
-| **Identity** | Workload Name, Type, Mode, Configuration, SKU | What this workload is and how it's configured |
-| **VM Configuration** | Driver Instance, Worker Instance, # Workers, Pricing Tiers | Instance types and cluster shape (Classic only) |
-| **Usage** | Hours/Month | How much this workload runs — calculated from runs/day or entered directly |
-| **Token Configuration** | Rate Type, Tokens/Month (M), DBU per 1M Tokens | For FMAPI workloads: token volumes and rates |
-| **DBU Costs** | DBU/Hour, Monthly DBUs, List Rate, Discount %, Discounted Rate, List Cost, Discounted Cost | The core Databricks billing — all formula-based |
-| **DSU Costs** | Monthly DSUs, List Rate, List Cost, Discounted Cost | Databricks-managed storage charges using the exact regional `DATABRICKS_STORAGE` rate |
-| **VM Costs** | Driver $/hr, Worker $/hr, Driver VM Cost, Worker VM Cost, Total VM Cost | Infrastructure costs for Classic compute (zero for Serverless) |
-| **Totals** | Total Cost (List), Total Cost (Discounted) | Combined DBU + DSU + VM costs at list and discounted rates |
+| **Identity** | #, Workload Name, Type, Mode, Configuration, SKU | What this workload is and how it's configured |
+| **VM Configuration** | Driver Node, Worker Node, Workers, Driver Tier, Worker Tier | Instance types and cluster shape (Classic only) |
+| **Usage** | Hours/Mo | How much this workload runs — calculated from runs/day or entered directly |
+| **Token Configuration** | Token Type, Tokens/Mo (M), DBU/1M Tokens | For FMAPI workloads: token volumes and rates |
+| **DBU Costs** | DBU/Hr, DBUs/Mo, DBU Rate (List), Discount %, DBU Rate (Disc.), DBU Cost (List), DBU Cost (Disc.) | The core Databricks billing — all formula-based |
+| **DSU Costs** | DSUs/Mo, DSU Rate (List), DSU Cost (List), DSU Cost (Disc.) | Databricks-managed storage charges using the exact regional `DATABRICKS_STORAGE` rate |
+| **VM Costs** | Driver VM $/Hr, Worker VM $/Hr, Driver VM Cost, Worker VM Cost, Total VM Cost | Infrastructure costs for Classic compute (zero for Serverless) |
+| **Totals** | Total Cost (List), Total Cost (Disc.) | Combined DBU + DSU + VM costs at list and discounted rates |
 | **Notes** | Notes | Workload-specific details (e.g., "Photon enabled", "Storage Optimized") |
 
 :::info Key Detail
@@ -64,7 +64,11 @@ Some workloads can produce additional rows:
 - **Unity AI Gateway** — One row for each enabled Inference Tables or Usage Tracking component
 - **Agent Evaluation** — Separate rows for evaluation input tokens, output tokens, and synthetic-data questions when enabled
 
-Only configured components are emitted. The totals row at the bottom uses `SUM` formulas that include every primary row and sub-row.
+Lakebase, Unity AI Gateway, and Agent Evaluation emit only configured or
+enabled components. Databricks Default Storage always emits all three
+component rows, including zero-quantity rows. AI Search emits a storage row
+when configured storage is greater than zero. The totals row uses `SUM`
+formulas that include every primary row and sub-row.
 
 ### 4. Workload Cost Summary
 

--- a/docs-site/docs/user-guide/exporting.md
+++ b/docs-site/docs/user-guide/exporting.md
@@ -34,7 +34,7 @@ The top rows display your estimate metadata:
 - Status and version number
 - Created and last-updated dates
 
-### 2. Workloads Table (30 Columns)
+### 2. Workloads Table (34 Columns)
 
 Each workload in your estimate produces a primary row. Workloads with separately priced components can add sub-rows. The columns are grouped by purpose:
 
@@ -45,8 +45,9 @@ Each workload in your estimate produces a primary row. Workloads with separately
 | **Usage** | Hours/Month | How much this workload runs — calculated from runs/day or entered directly |
 | **Token Configuration** | Rate Type, Tokens/Month (M), DBU per 1M Tokens | For FMAPI workloads: token volumes and rates |
 | **DBU Costs** | DBU/Hour, Monthly DBUs, List Rate, Discount %, Discounted Rate, List Cost, Discounted Cost | The core Databricks billing — all formula-based |
+| **DSU Costs** | Monthly DSUs, List Rate, List Cost, Discounted Cost | Databricks-managed storage charges using the exact regional `DATABRICKS_STORAGE` rate |
 | **VM Costs** | Driver $/hr, Worker $/hr, Driver VM Cost, Worker VM Cost, Total VM Cost | Infrastructure costs for Classic compute (zero for Serverless) |
-| **Totals** | Total Cost (List), Total Cost (Discounted) | Combined DBU + VM costs at list and discounted rates |
+| **Totals** | Total Cost (List), Total Cost (Discounted) | Combined DBU + DSU + VM costs at list and discounted rates |
 | **Notes** | Notes | Workload-specific details (e.g., "Photon enabled", "Storage Optimized") |
 
 :::info Key Detail
@@ -59,27 +60,46 @@ Some workloads can produce additional rows:
 
 - **Lakebase** — Compute, plus optional database storage, point-in-time restore, and snapshot rows
 - **AI Search** — Row 1: compute costs, optional reranker row, then storage costs (if storage GB > 0)
+- **Databricks Default Storage** — Stored data, Tier 1 operations, and Tier 2 operations
+- **Unity AI Gateway** — One row for each enabled Inference Tables or Usage Tracking component
+- **Agent Evaluation** — Separate rows for evaluation input tokens, output tokens, and synthetic-data questions when enabled
 
 Only configured components are emitted. The totals row at the bottom uses `SUM` formulas that include every primary row and sub-row.
 
-### 4. Cost Summary
+### 4. Workload Cost Summary
 
-Below the workloads table, a summary section shows:
-- Monthly and annual totals for DBU costs, VM costs, and combined total
+Below the workloads table, a pre-add-on summary shows:
+- Monthly and annual totals for DBU costs, DSU costs, VM costs, and combined workload cost
 - Totals at both list price and discounted price
 
-### 5. Legend
+### 5. Platform Add-on
+
+This section shows:
+
+- The selected add-on, if any
+- Product Spend at List, calculated from DBU and DSU list cost
+- The applied uplift and active promotion
+- Add-on list cost, negotiated discount, and final add-on cost
+
+VM infrastructure cost is excluded from the add-on calculation base.
+
+### 6. Final Estimate Summary
+
+The final summary combines workload and Platform Add-on costs. It shows monthly and annual values for workloads and add-ons at list and discounted prices, followed by the final estimate.
+
+### 7. Legend
 
 A color-coded legend explaining the column groups:
 - **Blue** — DBU-related costs (Databricks compute units)
+- **Violet** — DSU-related costs (Databricks storage units)
 - **Cyan** — Token-based pricing (FMAPI workloads)
 - **Pink** — Discount pricing (discounted DBU rate and cost)
 - **Green** — VM infrastructure costs (cloud provider)
-- **Purple** — Total cost (DBU + VM combined)
+- **Purple** — Workload total cost (DBU + DSU + VM combined)
 
 Orange headers are used for general workload identity columns (name, type, configuration, SKU, notes) but are not listed in the legend section.
 
-### 6. Assumptions & Notes
+### 8. Assumptions & Notes
 
 The bottom section documents:
 - That all pricing uses Databricks list rates
@@ -118,3 +138,4 @@ Since all cells use formulas, you can build additional analysis on top of the ex
 - The **discount percentage** column is editable in Excel. Set it to your negotiated rate and all costs recalculate
 - For FMAPI workloads, the token configuration columns show your volume assumptions — adjust these for different usage scenarios
 - Lakebase and AI Search storage-related costs can appear on separate rows. Include every emitted sub-row when referencing total costs
+- Review the Platform Add-on and Final Estimate sections rather than treating workload totals as the final estimate

--- a/docs-site/docs/user-guide/exporting.md
+++ b/docs-site/docs/user-guide/exporting.md
@@ -6,8 +6,8 @@ sidebar_position: 6
 
 Lakemeter exports your estimates to professionally formatted Excel spreadsheets — ready for RFP responses, procurement reviews, internal planning, or vendor comparisons.
 
-![Exporting an estimate to Excel — click Export, download completes](/img/gifs/export-excel.gif)
-*Animated: exporting an estimate — click the Export button and the Excel file downloads automatically.*
+![Exporting an estimate to Excel — click Excel, download completes](/img/gifs/export-excel.gif)
+*Animated: exporting an estimate — click the Excel button and the file downloads automatically.*
 
 ## How to Export
 

--- a/docs-site/docs/user-guide/faq.md
+++ b/docs-site/docs/user-guide/faq.md
@@ -52,15 +52,15 @@ The assistant can propose **new** workloads and can analyze your existing ones, 
 
 ### What format does the export use?
 
-Lakemeter exports to `.xlsx` (Excel) format. The file includes formula-based cells, color-coded headers, frozen panes, and a cost summary section. You can open it in Excel, Google Sheets, or any spreadsheet application. See the [Exporting guide](./exporting) for full details.
+Lakemeter exports to `.xlsx` (Excel) format. The file includes formula-based cells, color-coded headers, frozen panes, a workload summary, a Platform Add-on section, and a final estimate summary. You can open it in Excel, Google Sheets, or any spreadsheet application. See the [Exporting guide](./exporting) for full details.
 
 ### Can I apply my negotiated discount?
 
-Yes. Each workload row in the Excel export has a **Discount %** column. Enter your negotiated discount rate and all cost cells recalculate automatically using Excel formulas. You can also set different discounts per workload.
+Yes. Configure global, category, or SKU-specific discounts in the estimate. The Excel export shows list and discounted DBU and DSU costs. Platform Add-ons use a separate negotiated add-on discount that is applied after the published uplift.
 
 ### Why do some workloads show multiple rows in the export?
 
-Some workloads contain separately priced components. AI Search can add reranker and storage rows. Lakebase can include compute, storage, PITR, and snapshot rows when those quantities are configured. All emitted rows are included in the totals. See the [Exporting guide](./exporting#3-multi-row-workloads).
+Some workloads contain separately priced components. AI Search can add reranker and storage rows. Lakebase can include compute, storage, PITR, and snapshot rows. Databricks Default Storage emits stored-data and operation rows. All emitted rows are included in the totals. See the [Exporting guide](./exporting#3-multi-row-workloads).
 
 ### How are DBU rates determined?
 

--- a/docs-site/docs/user-guide/faq.md
+++ b/docs-site/docs/user-guide/faq.md
@@ -79,4 +79,4 @@ Common things to verify:
 2. **Number of workers** — Each worker multiplies both DBU and VM costs.
 3. **Acceleration and mode options** — Enable them only when they match the planned workload, then inspect the resulting DBU quantity.
 4. **Serverless vs Classic** — Serverless has no VM costs but higher DBU rates. Classic has both.
-5. **Discount** — The export shows list prices by default. Apply your discount in the Excel file.
+5. **Discount** — Configure the intended discount in the estimate. The Excel discount cells remain editable for additional what-if analysis.

--- a/docs-site/docs/user-guide/fmapi-databricks.md
+++ b/docs-site/docs/user-guide/fmapi-databricks.md
@@ -2,9 +2,9 @@
 sidebar_position: 13
 ---
 
-# FMAPI — Databricks Models Sizing
+# Foundation Models — Databricks Sizing
 
-> **Lakemeter UI name:** FMAPI - Databricks
+> **Lakemeter UI name:** Foundation Models (Databricks)
 
 Use this guide to model Databricks-hosted FMAPI consumption in Lakemeter. It explains the estimator inputs and calculation behavior, not model capabilities, model selection, or serving architecture.
 
@@ -12,7 +12,7 @@ For current FMAPI capabilities and availability, start from the [official Databr
 
 ## What Lakemeter estimates
 
-Each FMAPI - Databricks workload represents one model and one rate type. Lakemeter supports two calculation units:
+Each Foundation Models (Databricks) workload represents one model and one rate type. Lakemeter supports two calculation units:
 
 - Millions of tokens per month for token-based rate types
 - Hours per month for provisioned rate types
@@ -91,7 +91,7 @@ Lakemeter resolves the usage conversion and DBU price for the selected model, ra
 
 ## Excel export
 
-Each FMAPI - Databricks workload emits one row.
+Each Foundation Models (Databricks) workload emits one row.
 
 For token-based rows, the export records the model, rate type, token quantity in millions, DBU per million tokens, monthly DBUs, and DBU cost. For provisioned rows, it records hours, DBU per hour, monthly DBUs, and DBU cost instead.
 

--- a/docs-site/docs/user-guide/fmapi-proprietary.md
+++ b/docs-site/docs/user-guide/fmapi-proprietary.md
@@ -2,9 +2,9 @@
 sidebar_position: 15
 ---
 
-# FMAPI — Proprietary Models Sizing
+# Foundation Models — Proprietary Sizing
 
-> **Lakemeter UI name:** FMAPI - Proprietary
+> **Lakemeter UI name:** Foundation Models (Proprietary)
 
 Use this guide to model proprietary FMAPI token consumption in Lakemeter. It explains the estimator inputs and calculation behavior, not provider capabilities, model selection, endpoint routing, or context-window limits.
 
@@ -12,7 +12,7 @@ For current FMAPI capabilities and availability, start from the [official Databr
 
 ## What Lakemeter estimates
 
-Each FMAPI - Proprietary workload represents one selected provider, model, endpoint type, context length, rate type, and monthly token quantity.
+Each Foundation Models (Proprietary) workload represents one selected provider, model, endpoint type, context length, rate type, and monthly token quantity.
 
 Each rate type is a separate line item. Add one workload entry for every usage category that applies, such as input, output, cache read, or cache write when those choices are available for the selected configuration.
 
@@ -98,7 +98,7 @@ Use [FMAPI Token Pricing](./pricing/fmapi-tokens) to inspect the loaded rate com
 
 ## Excel export
 
-Each FMAPI - Proprietary workload emits one row. The row includes the model, rate type, token quantity in millions, DBU per million tokens, monthly DBUs, provider-specific SKU rate, and list and discounted DBU costs. The selected endpoint type and context length participate in the rate lookup but are not repeated as dedicated export columns.
+Each Foundation Models (Proprietary) workload emits one row. The row includes the model, rate type, token quantity in millions, DBU per million tokens, monthly DBUs, provider-specific SKU rate, and list and discounted DBU costs. The selected endpoint type and context length participate in the rate lookup but are not repeated as dedicated export columns.
 
 The export formula is:
 

--- a/docs-site/docs/user-guide/general-storage.md
+++ b/docs-site/docs/user-guide/general-storage.md
@@ -22,11 +22,11 @@ Stored-data DSUs = Stored GB-months × 1 DSU/GB-month
 
 ### Tier 1 operations
 
-Enter the monthly number of Tier 1 operations in thousands. Examples include higher-cost write, list, and metadata operations as classified by the applicable cloud pricing.
+Enter the monthly number of Tier 1 operations in thousands. Lakemeter uses this field for PUT, COPY, POST, and LIST operations.
 
 ### Tier 2 operations
 
-Enter the monthly number of Tier 2 operations in thousands. Examples include lower-cost read and retrieval operations as classified by the applicable cloud pricing.
+Enter the monthly number of other storage API operations in thousands.
 
 Use the operation tier shown by the current Databricks pricing source. Cloud providers can classify operations differently.
 

--- a/docs-site/docs/user-guide/general-storage.md
+++ b/docs-site/docs/user-guide/general-storage.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 20
+---
+
+# Databricks Default Storage Sizing
+
+> **Lakemeter UI name:** Databricks Default Storage
+
+Use this guide to estimate Databricks-managed storage and storage API operations. Lakemeter converts the entered quantities into Databricks Storage Units (DSUs) and prices them with the regional `DATABRICKS_STORAGE` SKU.
+
+This workload does not estimate customer-managed object storage, backups, data transfer, or compute that reads and writes the stored data.
+
+## Form inputs
+
+### Stored data
+
+Enter the average monthly quantity in GB or TB. Lakemeter converts 1 TB to 1,024 GB.
+
+```text
+Stored-data DSUs = Stored GB-months × 1 DSU/GB-month
+```
+
+### Tier 1 operations
+
+Enter the monthly number of Tier 1 operations in thousands. Examples include higher-cost write, list, and metadata operations as classified by the applicable cloud pricing.
+
+### Tier 2 operations
+
+Enter the monthly number of Tier 2 operations in thousands. Examples include lower-cost read and retrieval operations as classified by the applicable cloud pricing.
+
+Use the operation tier shown by the current Databricks pricing source. Cloud providers can classify operations differently.
+
+## How Lakemeter calculates cost
+
+The operation multipliers in the current pricing bundle are:
+
+- AWS and GCP: 0.2174 DSU per 1,000 Tier 1 operations and 0.0174 DSU per 1,000 Tier 2 operations
+- Azure: 0.3535 DSU per 1,000 Tier 1 operations and 0.0226 DSU per 1,000 Tier 2 operations
+
+```text
+Tier 1 DSUs = Tier 1 operations in thousands × Cloud Tier 1 multiplier
+Tier 2 DSUs = Tier 2 operations in thousands × Cloud Tier 2 multiplier
+
+Total DSUs
+  = Stored-data DSUs
+  + Tier 1 DSUs
+  + Tier 2 DSUs
+
+Monthly cost = Total DSUs × Regional price per DSU
+```
+
+The regional price is resolved from the `DATABRICKS_STORAGE` SKU for the estimate cloud, region, and tier.
+
+## What to review before saving
+
+- Is stored data an average GB-month quantity rather than a one-time upload?
+- Is the GB or TB unit correct?
+- Are operation counts entered in thousands?
+- Are operations assigned to the correct cloud-specific tier?
+- Does the expanded calculation show the expected DSU quantity and regional DSU price?
+- Have customer-managed storage and data transfer been modeled separately where required?
+
+## Excel export
+
+Each workload emits three component rows:
+
+1. Stored Data
+2. Tier 1 Operations
+3. Tier 2 Operations
+
+Each row shows its input quantity, DSU multiplier, monthly DSUs, list DSU rate, and monthly cost. Components remain visible when their quantity is zero so the calculation is auditable.
+
+## Related
+
+- [Calculation Reference](./calculation-reference)
+- [Exporting to Excel](./exporting)
+- [SKU Explorer](./pricing/sku-explorer)
+- [Databricks pricing](https://www.databricks.com/product/pricing/storage)

--- a/docs-site/docs/user-guide/getting-started.md
+++ b/docs-site/docs/user-guide/getting-started.md
@@ -95,13 +95,15 @@ Click on a workload to expand or edit it. Costs recalculate instantly when you c
 
 ## Step 5: Export to Excel
 
-1. Click the **Export** button (download icon) at the top of the calculator page.
+1. Click the **Excel** button (download icon) at the top of the calculator page.
 2. An Excel file downloads named something like `Databricks_Estimate_Q4_Data_Platform_AWS_20260404.xlsx`.
 
 The spreadsheet includes:
 - **Header section** with your estimate details (cloud, region, tier)
-- **Workload table** with every configuration field, DBU rates, and costs per workload
-- **Summary section** with total monthly cost and DBU breakdown by SKU type
+- **Workload table** with DBU, DSU, VM, list, and discounted costs
+- **Workload summary** before Platform Add-ons
+- **Platform Add-on section** with Product Spend at List and the applied uplift
+- **Final estimate summary** with monthly and annual totals
 - **Assumptions and notes** explaining the pricing basis
 
 This file is ready to attach to an RFP response, share in a planning meeting, or use for internal budgeting.

--- a/docs-site/docs/user-guide/lakebase.md
+++ b/docs-site/docs/user-guide/lakebase.md
@@ -19,7 +19,7 @@ A Lakebase workload can include:
 - Point-in-time restore storage
 - Snapshot storage
 
-Compute is modeled through a Databricks compute SKU. Storage-related quantities are modeled separately and only appear when their input is greater than zero.
+Compute is modeled through a Databricks compute SKU. Storage-related quantities are converted to DSUs, priced with the exact regional `DATABRICKS_STORAGE` rate, and only appear when their input is greater than zero.
 
 ## Choose a compute type
 
@@ -182,7 +182,20 @@ Enter monthly quantities for the components included in the scenario:
 | **Point-in-Time Restore (GB)** | Expected PITR storage quantity |
 | **Snapshot Storage (GB)** | Expected snapshot storage quantity |
 
-Lakemeter converts each configured quantity to its corresponding storage billing units and applies the loaded storage rate. The expanded calculation shows the multiplier and rate used. This guide does not duplicate those values because they can change.
+Lakemeter applies these DSU multipliers:
+
+- Database storage: 15 DSU per GB
+- Point-in-time restore: 8.7 DSU per GB
+- Snapshot storage: 3.91 DSU per GB
+
+```text
+Storage component cost
+  = Configured GB
+  × Component DSU per GB
+  × Regional DATABRICKS_STORAGE price per DSU
+```
+
+The expanded calculation shows the multiplier, DSU quantity, and regional rate used.
 
 ## What to review before saving
 
@@ -203,7 +216,7 @@ Lakebase can emit these rows:
 3. Point-in-time restore, when configured
 4. Snapshot storage, when configured
 
-The compute row includes the configured CU range, scale-to-zero setting, scale-up hours, node count, DBU quantity, and selected SKU rate. Storage-related rows remain separate so each quantity and charge can be reviewed independently.
+The compute row includes the configured CU range, scale-to-zero setting, scale-up hours, node count, DBU quantity, and selected SKU rate. Storage-related rows remain separate and report their DSU quantity and rate so each charge can be reviewed independently.
 
 The total Lakebase estimate is the sum of every emitted row.
 

--- a/docs-site/docs/user-guide/lakeflow-connect.md
+++ b/docs-site/docs/user-guide/lakeflow-connect.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 8
+---
+
+# Lakeflow Connect API Sizing
+
+Lakeflow Connect is currently available through Lakemeter's calculation API. It is not a supported workload form in the current release.
+
+The calculation models two possible components:
+
+1. A Lakeflow pipeline using serverless pipeline compute
+2. An optional classic gateway for database connectors
+
+## API endpoint
+
+```text
+POST /api/v1/calculate/lakeflow-connect
+```
+
+Example with direct monthly pipeline hours:
+
+```json
+{
+  "cloud": "AWS",
+  "region": "us-east-1",
+  "tier": "PREMIUM",
+  "dlt_edition": "ADVANCED",
+  "hours_per_month": 100,
+  "gateway_enabled": false
+}
+```
+
+Run-based pipeline usage can be expressed with:
+
+```json
+{
+  "runs_per_day": 2,
+  "avg_runtime_minutes": 60,
+  "days_per_month": 22
+}
+```
+
+Do not send direct monthly hours and run-based usage in the same request.
+
+## Optional gateway
+
+Database connectors can require an always-on gateway. Enable it and provide the gateway configuration:
+
+```json
+{
+  "gateway_enabled": true,
+  "gateway_instance_type": "i3.xlarge",
+  "gateway_pricing_tier": "on_demand",
+  "gateway_payment_option": "NA",
+  "gateway_hours_per_month": 730
+}
+```
+
+The response separates pipeline and gateway costs. Gateway cost can include both Databricks DBUs and cloud VM infrastructure.
+
+## Current limitation
+
+The Lakeflow Connect calculation path has known pipeline, gateway SKU, and run-based validation defects tracked in [GitHub issue #8](https://github.com/databrickslabs/lakemeter-oss/issues/8). Treat results as preliminary and verify the returned SKU, DBUs, VM cost, and hours before using them externally.
+
+## Related
+
+- [Lakeflow Spark Declarative Pipelines](./dlt-pipelines)
+- [Calculation Reference](./calculation-reference)
+- [API Reference](../admin-guide/api-reference)

--- a/docs-site/docs/user-guide/model-serving.md
+++ b/docs-site/docs/user-guide/model-serving.md
@@ -38,6 +38,8 @@ Concurrency is a cost multiplier in the estimate; it is not informational metada
 
 Enter the number of hours the endpoint is expected to be active during the month. This is a direct monthly input, so derive it from the planned endpoint schedule rather than request count alone.
 
+If hours are omitted, Lakemeter models the endpoint as always on for 730 hours per month.
+
 ## How cost is calculated
 
 Lakemeter resolves the endpoint's base DBU-per-hour rate, the selected concurrency, and the regional DBU price:

--- a/docs-site/docs/user-guide/platform-addons.md
+++ b/docs-site/docs/user-guide/platform-addons.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 22
+---
+
+# Platform Add-ons
+
+Platform Add-ons are estimate-level charges calculated as a percentage of eligible Databricks product spend. They are not independent workloads.
+
+Select an add-on beside the estimate cloud and pricing tier. Lakemeter validates whether the add-on is available for that combination.
+
+## Product Spend at List
+
+Lakemeter calculates the add-on from Databricks product spend before negotiated discounts:
+
+```text
+Product Spend at List
+  = DBU list cost
+  + DSU list cost
+```
+
+Cloud VM infrastructure cost is excluded. The add-on is also excluded from its own calculation base, preventing compounding.
+
+## Available add-ons
+
+### Enhanced Security and Compliance
+
+- AWS Enterprise: 15%
+- Azure Premium: 10%
+- GCP Enterprise: 15%
+
+### Mission Critical
+
+Mission Critical includes Enhanced Security and Compliance, so the two cannot be selected together.
+
+- AWS Enterprise: standard 30%
+- Azure Premium: standard 30%
+- Promotional rate: 15% through June 30, 2027
+
+Mission Critical is not present in the current GCP pricing catalog.
+
+Rates and eligibility reflect the pricing catalog bundled with the release. Confirm current eligibility and commercial terms before sharing a final estimate.
+
+## How Lakemeter calculates cost
+
+```text
+Add-on list cost
+  = Product Spend at List × Active uplift percentage
+
+Add-on cost after discount
+  = Add-on list cost × (1 − Add-on discount percentage)
+
+Grand total
+  = Workload cost after discounts
+  + Add-on cost after discount
+```
+
+Workload discounts do not reduce the add-on calculation base. A separate Platform Add-on discount can be applied after the uplift.
+
+## What to review
+
+- Is the estimate cloud and tier eligible?
+- Is the selected add-on the intended package?
+- Is a time-limited promotional rate active for the pricing date?
+- Does Product Spend at List contain DBU and DSU list cost but exclude VM cost?
+- Is the negotiated add-on discount separate from workload discounts?
+- Does the grand total include both workloads and the add-on?
+
+## Excel export
+
+The workbook separates the estimate into:
+
+1. Workload detail rows
+2. Workload cost summary before Platform Add-ons
+3. Platform Add-on summary
+4. Final estimate summary
+
+The add-on section shows Product Spend at List, the active uplift, promotion details when applicable, list add-on cost, negotiated discount, and discounted add-on cost. The final section combines workloads and add-ons into monthly and annual totals.
+
+## Related
+
+- [Calculation Reference](./calculation-reference)
+- [Exporting to Excel](./exporting)
+- [Databricks pricing](https://www.databricks.com/product/pricing/platform-addons)

--- a/docs-site/docs/user-guide/pricing/fmapi-tokens.md
+++ b/docs-site/docs/user-guide/pricing/fmapi-tokens.md
@@ -96,7 +96,7 @@ Monthly DBUs
   × DBUs per hour
 ```
 
-Create separate FMAPI workload lines for separately billed rate types such as input tokens, output tokens, cache reads, or cache writes. The [FMAPI — Proprietary sizing guide](../fmapi-proprietary) explains how those quantities are entered in an estimate.
+Create separate FMAPI workload lines for separately billed rate types such as input tokens, output tokens, cache reads, or cache writes. The [Foundation Models — Proprietary sizing guide](../fmapi-proprietary) explains how those quantities are entered in an estimate.
 
 ## Review checklist
 
@@ -109,7 +109,7 @@ Create separate FMAPI workload lines for separately billed rate types such as in
 
 ## Related
 
-- [FMAPI — Proprietary sizing](../fmapi-proprietary)
+- [Foundation Models — Proprietary sizing](../fmapi-proprietary)
 - [SKU Explorer](./sku-explorer)
 - [Calculation Reference](../calculation-reference)
 - [Official Databricks documentation](https://docs.databricks.com/)

--- a/docs-site/docs/user-guide/quick-reference.md
+++ b/docs-site/docs/user-guide/quick-reference.md
@@ -35,7 +35,7 @@ Use this page when reviewing an estimate. Workload-specific fields and formulas 
 | **List rate** | The rate loaded for the selected SKU, cloud, region, and tier. |
 | **Discount** | A planning adjustment applied to eligible list-rate costs. Confirm actual commercial terms separately. |
 | **VM cost** | Cloud infrastructure cost shown separately for calculations where Lakemeter models it independently. |
-| **Direct cost** | A cost calculated from a non-DBU billing quantity, such as an item quantity or a storage charge. |
+| **Direct cost** | A cost entered or calculated directly rather than derived from DBUs, DSUs, or separately modeled VMs. |
 | **Product Spend at List** | DBU and DSU list cost before discounts; the basis for Platform Add-ons. VM cost is excluded. |
 
 ## Review checklist

--- a/docs-site/docs/user-guide/quick-reference.md
+++ b/docs-site/docs/user-guide/quick-reference.md
@@ -30,11 +30,13 @@ Use this page when reviewing an estimate. Workload-specific fields and formulas 
 | Term | Meaning in Lakemeter |
 |---|---|
 | **DBU** | A Databricks billing unit. Lakemeter multiplies estimated DBU consumption by the selected SKU's list rate. |
+| **DSU** | A Databricks Storage Unit. Lakemeter multiplies DSU consumption by the exact regional `DATABRICKS_STORAGE` list rate. |
 | **SKU** | The priced Databricks product entry used for a calculation. |
 | **List rate** | The rate loaded for the selected SKU, cloud, region, and tier. |
 | **Discount** | A planning adjustment applied to eligible list-rate costs. Confirm actual commercial terms separately. |
 | **VM cost** | Cloud infrastructure cost shown separately for calculations where Lakemeter models it independently. |
 | **Direct cost** | A cost calculated from a non-DBU billing quantity, such as an item quantity or a storage charge. |
+| **Product Spend at List** | DBU and DSU list cost before discounts; the basis for Platform Add-ons. VM cost is excluded. |
 
 ## Review checklist
 

--- a/docs-site/docs/user-guide/vector-search.md
+++ b/docs-site/docs/user-guide/vector-search.md
@@ -18,7 +18,7 @@ An AI Search workload can include:
 - Storage above the first 30 GB included allowance
 - Optional AI Search Reranker requests
 
-Compute is modeled through a Databricks serverless compute SKU. Storage is calculated separately from DBU consumption.
+Compute and reranker requests are modeled through Databricks DBU SKUs. Storage is calculated separately in DSUs using the regional `DATABRICKS_STORAGE` rate.
 
 ## Configure the workload
 
@@ -78,8 +78,11 @@ Included storage
 Billable storage
   = MAX(0, Configured storage − Included storage)
 
+Storage DSUs
+  = Billable storage × DSU per GB for the selected type
+
 Storage cost
-  = Billable storage × Loaded storage rate
+  = Storage DSUs × Regional price per DSU
 
 Reranker DBUs
   = Reranker requests in thousands × 28.571 DBU
@@ -93,6 +96,8 @@ Total AI Search cost
 
 Configured storage can therefore produce a zero storage charge when it is within the included allowance.
 
+Standard AI Search uses 10 DSU per billable GB-month. Storage Optimized AI Search uses 2 DSU per billable GB-month.
+
 ## What to review before saving
 
 - Is the selected AI Search type the one being deployed?
@@ -100,6 +105,7 @@ Configured storage can therefore produce a zero storage charge when it is within
 - Does capacity include expected growth and duplicated or retained vectors?
 - Does the rounded capacity-unit count match the expanded calculation?
 - Is the storage value the total configured quantity, not only the expected billable excess?
+- Does the expanded calculation show the expected 10 or 2 DSU per billable GB and the regional DSU price?
 - Do hours represent the endpoint-active schedule?
 - Is the cloud, region, and pricing tier correct for the estimate?
 
@@ -123,7 +129,7 @@ AI Search emits:
 
 The storage sub-row is emitted whenever configured storage is greater than zero, even when the included allowance reduces billable storage and storage cost to zero. This matches the current export behavior.
 
-The compute row includes the selected type, capacity, hours, effective DBU per hour, monthly DBUs, and selected SKU rate. The reranker row shows requests, DBU per 1,000 requests, and regional SKU rate. The storage row keeps configured, included, and billable storage separate from compute. The total AI Search estimate is the sum of all emitted rows.
+The compute row includes the selected type, capacity, hours, effective DBU per hour, monthly DBUs, and selected SKU rate. The reranker row shows requests, DBU per 1,000 requests, and regional SKU rate. The storage row keeps configured, included, and billable storage separate from compute and reports its DSU quantity and rate. The total AI Search estimate is the sum of all emitted rows.
 
 ## Related
 

--- a/docs-site/docs/user-guide/vector-search.md
+++ b/docs-site/docs/user-guide/vector-search.md
@@ -48,6 +48,8 @@ Leave this field at zero when storage should not be included in the estimate.
 
 Enter the number of hours the endpoint is expected to be active during the month.
 
+If hours are omitted, Lakemeter models the endpoint as always on for 730 hours per month.
+
 ## How compute cost is calculated
 
 ```text

--- a/docs-site/docs/user-guide/workloads.md
+++ b/docs-site/docs/user-guide/workloads.md
@@ -18,16 +18,17 @@ For current Databricks product capabilities and availability, refer to the [offi
 | Scheduled or triggered processing | [Lakeflow Jobs](./jobs-compute) | Compute shape, workers, runs, runtime |
 | Interactive notebook compute | [All-Purpose Compute](./all-purpose-compute) | Compute shape, workers, active hours |
 | Declarative data pipelines | [Lakeflow Spark Declarative Pipelines](./dlt-pipelines) | Compute mode, edition, workers, usage |
+| Managed connector pipelines through the API | [Lakeflow Connect API](./lakeflow-connect) | Pipeline usage, edition, optional gateway |
 | SQL warehouses | [Databricks SQL](./dbsql-warehouses) | Warehouse type, size, clusters, hours |
 
 ## AI, ML, and data services
 
 | What you need to size | Lakemeter guide | Main sizing inputs |
 |---|---|---|
-| Model inference endpoints | [Model Serving](./model-serving) | Endpoint type, endpoint count, hours |
+| Model inference endpoints | [Model Serving](./model-serving) | Endpoint type, scale-out concurrency, hours |
 | Vector indexing and search | [AI Search](./vector-search) | Endpoint mode, vector capacity, storage, reranker requests, hours |
-| Databricks-hosted foundation models | [FMAPI — Databricks](./fmapi-databricks) | Model, rate type, token volume or hours |
-| Proprietary foundation models | [FMAPI — Proprietary](./fmapi-proprietary) | Provider, model, geography, context, token volume |
+| Databricks-hosted foundation models | [Foundation Models — Databricks](./fmapi-databricks) | Model, rate type, token volume or hours |
+| Proprietary foundation models | [Foundation Models — Proprietary](./fmapi-proprietary) | Provider, model, geography, context, token volume |
 | Transactional database capacity | [Lakebase](./lakebase) | Compute range, usage, nodes, storage protection |
 | Databricks-hosted applications | [Databricks Apps](./databricks-apps) | App size, app count, active hours |
 | Document parsing | [AI Parse](./ai-parse) | Estimation mode, document complexity, page volume |
@@ -37,6 +38,14 @@ For current Databricks product capabilities and availability, refer to the [offi
 | Agent evaluation service usage | [Agent Evaluation](./agent-evaluation) | Features enabled, evaluation token volume, synthetic questions |
 | Serverless GPU model training | [AI Runtime](./ai-runtime) | Accelerator, monthly runtime |
 | Image generation | [Shutterstock ImageAI](./shutterstock-imageai) | Monthly image volume |
+
+## Ingestion, storage, and platform
+
+| What you need to size | Lakemeter guide | Main sizing inputs |
+|---|---|---|
+| Direct or OpenTelemetry ingestion | [Zerobus Ingest](./zerobus) | Mode, monthly ingested GB |
+| Databricks-managed default storage | [Databricks Default Storage](./general-storage) | Stored data, Tier 1 operations, Tier 2 operations |
+| Security and mission-critical packages | [Platform Add-ons](./platform-addons) | Add-on selection, cloud, tier, Product Spend at List |
 
 ## Shared sizing principles
 

--- a/docs-site/docs/user-guide/zerobus.md
+++ b/docs-site/docs/user-guide/zerobus.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 21
+---
+
+# Zerobus Ingest Sizing
+
+> **Lakemeter UI name:** Zerobus Ingest
+
+Use this guide to estimate the Databricks DBU charge for data ingested through Zerobus. Lakemeter supports standard Zerobus ingestion and OpenTelemetry (OTel) ingestion.
+
+Zerobus is volume-based in Lakemeter. It is not sized from cluster hours.
+
+## Form inputs
+
+### Ingestion mode
+
+- **Standard** — direct Zerobus ingestion at 0.143 DBU per GB
+- **OTel** — OpenTelemetry ingestion at 0.222 DBU per GB
+
+### Monthly ingested data
+
+Enter the total data volume sent through Zerobus during the month in GB.
+
+## Availability
+
+Lakemeter exposes Zerobus pricing for:
+
+- AWS: Premium and Enterprise
+- Azure: Premium
+- GCP: Premium and Enterprise
+
+The form rejects unsupported cloud and tier combinations.
+
+## How Lakemeter calculates cost
+
+Both modes use the regional `JOBS_SERVERLESS_COMPUTE` SKU price.
+
+```text
+Monthly DBUs = Monthly ingested GB × DBU per GB for the selected mode
+
+Monthly cost = Monthly DBUs × Regional Jobs Serverless price per DBU
+```
+
+Example for 1,000 GB:
+
+```text
+Standard: 1,000 × 0.143 = 143 DBUs
+OTel:     1,000 × 0.222 = 222 DBUs
+```
+
+## Costs not included
+
+The Zerobus workload excludes:
+
+- Producer or collector compute
+- Target Delta table storage
+- Downstream processing
+- Data transfer or network egress
+
+Add separate Lakemeter workloads for supported components and model external costs outside Lakemeter where necessary.
+
+## What to review before saving
+
+- Is the mode Standard or OTel?
+- Is the quantity the complete monthly ingested volume in GB?
+- Is the selected cloud and tier supported?
+- Does the expanded calculation show 0.143 or 0.222 DBU per GB?
+- Have storage, producer compute, downstream processing, and transfer costs been considered separately?
+
+## Excel export
+
+Zerobus emits one DBU row. The configuration shows the selected mode, monthly ingested GB, and DBU-per-GB conversion. VM and DSU columns remain zero.
+
+## Related
+
+- [Calculation Reference](./calculation-reference)
+- [Exporting to Excel](./exporting)
+- [Jobs Compute](./jobs-compute)
+- [Databricks pricing](https://www.databricks.com/product/pricing)

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -23,6 +23,8 @@ const sidebars: SidebarsConfig = {
         'user-guide/jobs-compute',
         'user-guide/all-purpose-compute',
         'user-guide/dlt-pipelines',
+        'user-guide/lakeflow-connect',
+        'user-guide/zerobus',
         'user-guide/dbsql-warehouses',
       ],
     },
@@ -44,6 +46,15 @@ const sidebars: SidebarsConfig = {
         'user-guide/agent-evaluation',
         'user-guide/ai-runtime',
         'user-guide/shutterstock-imageai',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Storage & Platform',
+      collapsed: false,
+      items: [
+        'user-guide/general-storage',
+        'user-guide/platform-addons',
       ],
     },
     {

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -23,7 +23,11 @@ const sidebars: SidebarsConfig = {
         'user-guide/jobs-compute',
         'user-guide/all-purpose-compute',
         'user-guide/dlt-pipelines',
-        'user-guide/lakeflow-connect',
+        {
+          type: 'doc',
+          id: 'user-guide/lakeflow-connect',
+          label: 'Lakeflow Connect (API)',
+        },
         'user-guide/zerobus',
         'user-guide/dbsql-warehouses',
       ],


### PR DESCRIPTION
## Summary
- add user guides for Databricks Default Storage, Zerobus, Platform Add-ons, and the Lakeflow Connect API
- align Apps, AI Search, Lakebase, Foundation Models, API, upgrade, and calculation references with current v0.3 behavior
- document the 34-column Excel layout, DSU accounting, add-on summaries, and current workload catalog

## Test plan
- [x] `npm run build --prefix docs-site`
- [x] `python -m pytest tests/docs_media/test_image_references.py tests/docs_media/test_screenshot_audit.py -q` (134 passed)
- [x] Docusaurus broken-link validation