### PR TITLE
Document rollback re-upgrade procedure

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,7 +68,7 @@ reviewed and edited by hand.
 
 6. Run the release-candidate workflow against `main`. Set `publish_tag=true`
    only when the workflow should create the final tag after all installation,
-   upgrade, end-to-end, and rollback gates pass:
+   upgrade, end-to-end, rollback, and re-upgrade gates pass:
 
    ```bash
    gh workflow run release-candidate.yml \

--- a/docs-site/docs/admin-guide/upgrading.md
+++ b/docs-site/docs/admin-guide/upgrading.md
@@ -234,6 +234,19 @@ Expected response:
 }
 ```
 
+Rollback restores the previous application source and installation metadata
+and leaves the original production branch unchanged. To return to the newer
+release, keep its clean checkout and run the supported upgrade flow again:
+
+```bash
+./scripts/upgrade.sh plan --profile <profile>
+./scripts/upgrade.sh doctor --profile <profile>
+./scripts/upgrade.sh apply --profile <profile>
+```
+
+The upgrader creates a new recovery point from the active rollback branch and
+applies the updates required by the restored installation version.
+
 ## Troubleshooting
 
 ### Repository has uncommitted changes

--- a/tests/upgrade/test_release_workflow_gate.py
+++ b/tests/upgrade/test_release_workflow_gate.py
@@ -24,9 +24,21 @@ def test_candidate_runs_cross_version_integration_before_tagging():
     artifact_position = CANDIDATE_WORKFLOW.index(
         "Upload tested release assets"
     )
+    rollback_position = CANDIDATE_WORKFLOW.index(
+        "Verify manual rollback"
+    )
+    reupgrade_position = CANDIDATE_WORKFLOW.index(
+        "Verify upgrade after rollback"
+    )
     tag_position = CANDIDATE_WORKFLOW.index(
         "Create immutable release tag"
     )
+    reupgrade_block = CANDIDATE_WORKFLOW[
+        reupgrade_position:artifact_position
+    ]
+    assert "./scripts/upgrade.sh apply" in reupgrade_block
+    assert "scripts/release_integration.py verify" in reupgrade_block
+    assert rollback_position < reupgrade_position < artifact_position
     assert artifact_position < tag_position
 
 


### PR DESCRIPTION
## Summary
- document the supported operator flow for upgrading again after rollback
- align the maintainer release guide with the rollback-to-re-upgrade gate
- enforce ordering and commands for the second upgrade in the workflow policy test

## Test plan
- [x] `python -m pytest tests/upgrade/test_release_workflow_gate.py tests/docs_media/test_docs_build.py -q`
- [x] `npm run build --prefix docs-site`